### PR TITLE
feat(model): add dummy text encoder for constraint-only generation

### DIFF
--- a/kimodo/model/llm2vec/llm2vec_wrapper.py
+++ b/kimodo/model/llm2vec/llm2vec_wrapper.py
@@ -71,3 +71,46 @@ class LLM2VecEncoder:
 
         encoded_text = torch.tensor(encoded_text).to(self.get_device())
         return encoded_text, lengths
+
+
+class DummyTextEncoder:
+    """Zero-vector text encoder for constraint-only generation without LLM weights.
+
+    Activated by setting TEXT_ENCODER_MODE=dummy. Returns zero embeddings
+    of the correct shape (llm_dim=4096), which the model treats as
+    unconditional (same as empty-text in classifier-free guidance training).
+
+    This allows running Kimodo on GPUs with <17GB VRAM and without
+    Llama-3 access, using only kinematic constraints for motion control.
+    """
+
+    def __init__(self, llm_dim: int = 4096, device: str = "cuda:0") -> None:
+        self.llm_dim = llm_dim
+        self._device = torch.device(device)
+        print(f"[Kimodo] Using DummyTextEncoder (zero embeddings, dim={llm_dim})")
+        print("[Kimodo] Text prompts will be ignored. Use constraints for motion control.")
+
+    def to(self, device: torch.device):
+        self._device = torch.device(device)
+        return self
+
+    def eval(self):
+        return self
+
+    def get_device(self):
+        return self._device
+
+    def __call__(self, text: list[str] | str):
+        is_string = False
+        if isinstance(text, str):
+            text = [text]
+            is_string = True
+
+        encoded_text = torch.zeros(len(text), 1, self.llm_dim, device=self._device)
+        lengths = np.ones(len(text), dtype=int).tolist()
+
+        if is_string:
+            encoded_text = encoded_text[0]
+            lengths = lengths[0]
+
+        return encoded_text, lengths

--- a/kimodo/model/load_model.py
+++ b/kimodo/model/load_model.py
@@ -81,8 +81,14 @@ def _select_text_encoder_conf(text_encoder_url: str) -> dict:
     # TEXT_ENCODER_MODE options:
     # - "api": force TextEncoderAPI
     # - "local": force local LLM2VecEncoder
+    # - "dummy": zero-vector encoder (no LLM needed, constraint-only)
     # - "auto": try API first, fallback to local if unreachable
     mode = get_env_var("TEXT_ENCODER_MODE", "auto").lower()
+    if mode == "dummy":
+        return {
+            "_target_": "kimodo.model.llm2vec.llm2vec_wrapper.DummyTextEncoder",
+            "llm_dim": 4096,
+        }
     if mode == "local":
         return _build_local_text_encoder_conf()
     if mode == "api":


### PR DESCRIPTION
First of all, thank you for building and open-sourcing Kimodo. It is a great project.

## Summary
- Add `TEXT_ENCODER_MODE=dummy` option that replaces the LLM2Vec text encoder with a zero-vector encoder
- Enables constraint-only motion generation (keyframes, end-effectors, root paths) without text prompts

## Motivation
Some use cases only need kinematic constraints to control motion generation, without any text prompts. For example, robotics pipelines or animation workflows that already have precise keyframe/end-effector targets do not benefit from text conditioning.

Currently there is no way to skip the text encoder. Even with an empty prompt, Kimodo always loads the full Llama-3-8B model (~17GB VRAM). This change adds a lightweight `DummyTextEncoder` that returns zero embeddings (equivalent to the unconditional case in classifier-free guidance training), so the diffusion model can run with constraints alone.

As a side benefit, this also helps users who cannot load the text encoder due to VRAM limitations (<17GB) or pending Meta Llama gated repo approval.

## Usage
```bash
TEXT_ENCODER_MODE=dummy kimodo_gen "" --constraints constraints.json --output motion
```