### PR TITLE
Fix: remove unnecessary text encoder reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [2026-04-01]
+
+### Fixed
+- Fix unnecessary text encoder reload when switching between models in the interactive demo (if not using the text encoder server API).
 
 ## [2026-03-31]
 

--- a/kimodo/demo/app.py
+++ b/kimodo/demo/app.py
@@ -57,6 +57,7 @@ class Demo:
         self.device = "cuda:0" if torch.cuda.is_available() else "cpu"
         print(f"Using device: {self.device}")
         self.models: dict[str, ModelBundle] = {}
+        self._text_encoder = None
         resolved = resolve_model_name(default_model_name, "Kimodo")
         if resolved not in MODEL_NAMES:
             raise ValueError(f"Unknown model '{default_model_name}'. Expected one of: {MODEL_NAMES}")
@@ -129,12 +130,18 @@ class Demo:
 
         print(f"Loading model {model_name}...")
         try:
-            model = load_model(modelname=model_name, device=self.device)
+            model = load_model(
+                modelname=model_name,
+                device=self.device,
+                text_encoder=self._text_encoder,
+            )
         except Exception as e:
             print(f"Error loading model: {e}\nMake sure text encoder server is running!")
             raise e
 
         if hasattr(model, "text_encoder"):
+            if self._text_encoder is None:
+                self._text_encoder = model.text_encoder
             model.text_encoder = CachedTextEncoder(model.text_encoder, model_name=model_name)
 
         skeleton = model.motion_rep.skeleton

--- a/kimodo/model/load_model.py
+++ b/kimodo/model/load_model.py
@@ -108,6 +108,7 @@ def load_model(
     eval_mode: bool = True,
     default_family: Optional[str] = "Kimodo",
     return_resolved_name: bool = False,
+    text_encoder=None,
 ):
     """Load a kimodo model by name (e.g. 'g1', 'soma').
 
@@ -126,6 +127,8 @@ def load_model(
             Default "Kimodo".
         return_resolved_name: If True, return (model, resolved_short_key). If False,
             return only the model.
+        text_encoder: Pre-built text encoder to reuse. When provided, skips
+            text encoder selection/instantiation entirely.
 
     Returns:
         Loaded model in eval mode, or (model, resolved short key) if
@@ -176,17 +179,30 @@ def load_model(
         # Same process at the moment for TMR and Kimodo
         pass
 
-    text_encoder_url = get_env_var("TEXT_ENCODER_URL", DEFAULT_TEXT_ENCODER_URL)
-    runtime_conf = OmegaConf.create(
-        {
-            "checkpoint_dir": str(model_path),
-            "text_encoder": _select_text_encoder_conf(text_encoder_url),
-        }
-    )
+    if text_encoder is not None:
+        runtime_conf = OmegaConf.create({"checkpoint_dir": str(model_path)})
+    else:
+        text_encoder_url = get_env_var("TEXT_ENCODER_URL", DEFAULT_TEXT_ENCODER_URL)
+        runtime_conf = OmegaConf.create(
+            {
+                "checkpoint_dir": str(model_path),
+                "text_encoder": _select_text_encoder_conf(text_encoder_url),
+            }
+        )
+
     model_cfg = OmegaConf.to_container(OmegaConf.merge(model_conf, runtime_conf), resolve=True)
     model_cfg.pop("checkpoint_dir", None)
 
+    if text_encoder is not None:
+        # Prevent Hydra from instantiating a new text encoder; pass None so
+        # Kimodo.__init__ receives a placeholder we replace immediately after.
+        model_cfg["text_encoder"] = None
+
     model = instantiate_from_dict(model_cfg, overrides={"device": device})
+
+    if text_encoder is not None:
+        model.text_encoder = text_encoder
+
     if eval_mode:
         model = model.eval()
     if return_resolved_name:


### PR DESCRIPTION
Remove unnecessary text encoder reload when switching models in the demo if not using the text encoder API backend.