### PR TITLE
Add motion generation benchmark and evaluation pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2026-04-10]
+
+### Added
+- [Kimodo-SOMA-RP-v1.1](https://huggingface.co/nvidia/Kimodo-SOMA-RP-v1.1) and [Kimodo-SOMA-SEED-v1.1](https://huggingface.co/nvidia/Kimodo-SOMA-SEED-v1.1) models and added support in the codebase. If not specified, the latest version of the models will be used automatically with the demo and CLI.
+- [Kimodo Motion Generation Benchmark](https://huggingface.co/datasets/nvidia/Kimodo-Motion-Gen-Benchmark) for standardized evaluation of motion generation models training on the BONES-SEED dataset.
+- Scripts to construct the full benchmark, generate motions for test cases, and compute evaluation metrics. 
+- Documentation explaining the benchmark and how to use the evaluation pipeline.
+- [TMR-SOMA-RP-v1](https://huggingface.co/nvidia/TMR-SOMA-RP-v1) motion-text embedding model to be used for evaluation metrics.
+- Added option to load LLM2Vec text encoder in fp32 precision.
+
+### Fixed
+- Always use batch size 1 with LLM2Vec to avoid unexpected behavior of different embeddings based on batch size.
+- Load LLM2Vec directly onto the GPU, if available.
+- Updated documentation on constraints with more details.
+
 ## [2026-04-01]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository provides:
 - **Inference**: code and CLI to generate motions on both human and robot skeletons
 - **Interactive Demo**: easily author motions with a timeline interface of text prompts and kinematic controls
 - **Annotations**: [additional text descriptions](https://huggingface.co/datasets/nvidia/SEED-Timeline-Annotations) for the [BONES-SEED](https://huggingface.co/datasets/bones-studio/seed) dataset, including fine-grained temporal descriptions
-- _[Coming Soon]_ **Benchmark**: test cases and evaluation code built on the [BONES-SEED](https://huggingface.co/datasets/bones-studio/seed) dataset to evaluate motion generation models based on text and constraint-following abilities
+- **Benchmark**: [test cases](https://huggingface.co/datasets/nvidia/Kimodo-Motion-Gen-Benchmark) and evaluation code built on the [BONES-SEED](https://huggingface.co/datasets/bones-studio/seed) dataset to evaluate motion generation models based on text and constraint-following abilities
 
 <div align="center">
   <img src="assets/teaser.gif" width="1280">
@@ -23,18 +23,21 @@ This repository provides:
 
 See the [full changelog](CHANGELOG.md) for a detailed list of all changes.
 
+- **[2026-04-10]** _NEW_: Released the [Kimodo Motion Generation Benchmark](#kimodo-motion-generation-benchmark) alongside new v1.1 Kimodo-SOMA models
 - **[2026-03-19]** **Breaking:** Model inputs/outputs now use the SOMA 77-joint skeleton (`somaskel77`).
 - **[2026-03-16]** Initial open-source release of Kimodo with five model variants (SOMA, G1, SMPL-X), CLI, interactive demo, and timeline annotations for BONES-SEED.
 
 
 ## Kimodo Models
 
-Several variations of Kimodo-v1 are available trained on various skeletons and datasets. All models support text-to-motion and kinematic controls.
+Several variations of Kimodo are available trained on various skeletons and datasets. All models support text-to-motion and kinematic controls.
 
 > Note: models will be downloaded automatically when attempting to generate from the CLI or Interactive Demo, so there is no need to download them manually
 
 | Model | Skeleton | Training Data | Release Date | Hugging Face | License |
 |:-------|:-------------|:------:|:------:|:-------------:|:-------------:|
+| **Kimodo-SOMA-RP-v1.1** | [SOMA](https://github.com/NVlabs/SOMA-X) | [Bones Rigplay 1](https://bones.studio/datasets#rp01) | April 10, 2026 | [Link](https://huggingface.co/nvidia/Kimodo-SOMA-RP-v1.1) | [NVIDIA Open Model](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/) |
+| **Kimodo-SOMA-SEED-v1.1** | [SOMA](https://github.com/NVlabs/SOMA-X) | [BONES-SEED](https://huggingface.co/datasets/bones-studio/seed) | April 10, 2026  | [Link](https://huggingface.co/nvidia/Kimodo-SOMA-SEED-v1.1) | [NVIDIA Open Model](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/) |
 | **Kimodo-SOMA-RP-v1** | [SOMA](https://github.com/NVlabs/SOMA-X) | [Bones Rigplay 1](https://bones.studio/datasets#rp01) | March 16, 2026 | [Link](https://huggingface.co/nvidia/Kimodo-SOMA-RP-v1) | [NVIDIA Open Model](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/) |
 | **Kimodo-G1-RP-v1** | [Unitree G1](https://github.com/unitreerobotics/unitree_mujoco/tree/main/unitree_robots/g1) | [Bones Rigplay 1](https://bones.studio/datasets#rp01) | March 16, 2026  | [Link](https://huggingface.co/nvidia/Kimodo-G1-RP-v1) | [NVIDIA Open Model](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/) |
 | **Kimodo-SOMA-SEED-v1** | [SOMA](https://github.com/NVlabs/SOMA-X) | [BONES-SEED](https://huggingface.co/datasets/bones-studio/seed) | March 16, 2026  | [Link](https://huggingface.co/nvidia/Kimodo-SOMA-SEED-v1) | [NVIDIA Open Model](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/) |
@@ -42,7 +45,10 @@ Several variations of Kimodo-v1 are available trained on various skeletons and d
 | **Kimodo-SMPLX-RP-v1** | [SMPL-X](https://github.com/vchoutas/smplx) | [Bones Rigplay 1](https://bones.studio/datasets#rp01) | March 16, 2026  | [Link](https://huggingface.co/nvidia/Kimodo-SMPLX-RP-v1) | [NVIDIA R&D Model](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-internal-scientific-research-and-development-model-license/) |
 
 By default, we recommend using the models trained on the full Bones Rigplay 1 dataset (700 hours of mocap) for your motion generation needs.
-The models trained on BONES-SEED use 288 hours of [publicly available mocap data](https://huggingface.co/datasets/bones-studio/seed) so are less capable, but are useful for comparing your own trained models on the same dataset. Soon, we will be releasing a benchmark to make it easy to compare motion generation models trained on BONES-SEED.
+The models trained on BONES-SEED use 288 hours of [publicly available mocap data](https://huggingface.co/datasets/bones-studio/seed) so are less capable, but are useful for comparing to other models trained on BONES-SEED. To easily compare motion generation models to Kimodo, check out our [Motion Generation Benchmark](#kimodo-motion-generation-benchmark).
+
+### Changes in v1.1
+The latest v1.1 Kimodo-SOMA models were released primarily for compatibility with our new [Motion Generation Benchmark](#kimodo-motion-generation-benchmark), but also contain minor quality improvements over v1. For details on these improvements, please see the Hugging Face pages for [Kimodo-SOMA-RP-v1.1](https://huggingface.co/nvidia/Kimodo-SOMA-RP-v1.1#changes-in-v11) and [Kimodo-SOMA-SEED-v1.1](https://huggingface.co/nvidia/Kimodo-SOMA-SEED-v1.1#changes-in-v11).
 
 ## Getting Started
 
@@ -53,14 +59,16 @@ Please see the full documentation for detailed installation instructions, how to
 - [Installation Instructions](https://research.nvidia.com/labs/sil/projects/kimodo/docs/getting_started/installation.html)
 - [Interactive Motion Authoring Demo](https://research.nvidia.com/labs/sil/projects/kimodo/docs/interactive_demo/index.html)
 - [Command-Line Interface](https://research.nvidia.com/labs/sil/projects/kimodo/docs/user_guide/cli.html)
+- [Benchmark Instructions](https://research.nvidia.com/labs/sil/projects/kimodo/docs/benchmark/introduction.html)
 - [API Reference](https://research.nvidia.com/labs/sil/projects/kimodo/docs/api_reference/index.html)
+
+**Before getting started** with motion generation, please review the [best practices](https://research.nvidia.com/labs/sil/projects/kimodo/docs/key_concepts/limitations.html) and be aware of [model limitations](https://research.nvidia.com/labs/sil/projects/kimodo/docs/key_concepts/limitations.html#limitations).
+
 
 Some notes on installation environment:
 - Kimodo requires ~17GB of VRAM to generate locally, primarily due to the text embedding model
 - The model has been most extensively tested on GeForce RTX 3090, GeForce RTX 4090, and NVIDIA A100 GPUs, but should work on other recent cards with sufficient VRAM
 - This repo was developed on Linux, though Windows should work especially if using Docker
-
-Before getting started with motion generation, please review the [best practices](https://research.nvidia.com/labs/sil/projects/kimodo/docs/key_concepts/limitations.html) and be aware of [model limitations](https://research.nvidia.com/labs/sil/projects/kimodo/docs/key_concepts/limitations.html#limitations).
 
 ## Interactive Motion Authoring Demo
 
@@ -167,6 +175,20 @@ GMR supports the AMASS NPZ format out of the box, so simply generate motions wit
 python scripts/smplx_to_robot.py --smplx_file /path/to/saved/amass_format.npz --robot booster_t1
 ```
 
+## Kimodo Motion Generation Benchmark
+
+[**[Benchmark Documentation](https://research.nvidia.com/labs/sil/projects/kimodo/docs/benchmark/introduction.html)**]
+[**[Test Suite on Hugging Face](https://huggingface.co/datasets/nvidia/Kimodo-Motion-Gen-Benchmark)**]
+
+Alongside the Kimodo models, we provide a benchmark designed to standardize evaluation for motion generation models with a comprehensive set of test cases. This includes:
+
+* **Evaluation Data**: A suite of test cases [available on Hugging Face](https://huggingface.co/datasets/nvidia/Kimodo-Motion-Gen-Benchmark) is used in concert with the [BONES-SEED](https://huggingface.co/datasets/bones-studio/seed) dataset to construct the full benchmark. 
+* **Diverse Test Cases**: Test cases cover a wide range of text-conditioned and constraint-conditioned motion generation.
+* **Evaluation Pipeline**: Code for the full evaluation pipeline including benchmark construction, motion generation, and evaluation.
+* **Metrics**: Several metrics to evaluate generated motions that cover motion quality, constraint following, and text alignment. Our [TMR-SOMA-RP-v1](https://huggingface.co/nvidia/TMR-SOMA-RP-v1) model trained on all 700 hours of the Bones Rigplay dataset is a powerful embedding model to compute common metrics like R-precision and FID.
+
+To facilitate future research, we [report benchmark results](https://research.nvidia.com/labs/sil/projects/kimodo/docs/benchmark/results.html) for Kimodo-SOMA-v1.1 models, which are reproducible and easily comparable to other methods trained on the BONES-SEED data. 
+
 ## Timeline Annotations for BONES-SEED
 
 As detailed in the [tech report](https://research.nvidia.com/labs/sil/projects/kimodo/assets/kimodo_tech_report.pdf), Kimodo is trained using fine-grained temporal text annotations of mocap clips.
@@ -212,6 +234,6 @@ This project builds upon excellent open-source projects:
 
 ## Contact
 
-For questions or issues, plese open an issue on this repository or reach out directly to the authors.
+For questions or issues, please open an issue on this repository or reach out directly to the authors.
 
 ---

--- a/benchmark/create_benchmark.py
+++ b/benchmark/create_benchmark.py
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Step (1) of evaluation pipeline.
+
+This script builds the benchmark test suites from BVH motions in the Bones-SEED dataset using 
+the benchmark metadata. Currently it is only set up for the SOMA skeleton.
+"""
+
+import argparse
+from functools import partial
+from multiprocessing import Pool
+from pathlib import Path
+
+import numpy as np
+import torch
+from tqdm import tqdm
+
+from kimodo.geometry import matrix_to_axis_angle
+from kimodo.motion_rep import KimodoMotionRep
+from kimodo.skeleton import SOMASkeleton77
+from kimodo.skeleton.bvh import parse_bvh_motion
+from kimodo.tools import load_json, save_json, to_numpy, to_torch
+
+FPS = 30
+BENCHMARK_REPO_ID = "nvidia/Kimodo-Motion-Gen-Benchmark"
+
+
+def download_benchmark(dest: Path) -> Path:
+    """Download the benchmark testsuite from HuggingFace to *dest*."""
+    from huggingface_hub import snapshot_download
+
+    print(f"Downloading benchmark testsuite from {BENCHMARK_REPO_ID} to {dest} ...")
+    snapshot_dir = snapshot_download(
+        repo_id=BENCHMARK_REPO_ID,
+        repo_type="dataset",
+        local_dir=str(dest),
+    )
+    return Path(snapshot_dir)
+
+
+def discover_seed_motion_folders(root: Path) -> list[Path]:
+    """Find all directories under root that contain seed_motion.json; return sorted list of those
+    dirs."""
+    root = root.resolve()
+    if not root.is_dir():
+        raise FileNotFoundError(f"Folder does not exist: {root}")
+    out: list[Path] = []
+    for meta_path in root.rglob("seed_motion.json"):
+        src_dir = meta_path.parent
+        out.append(src_dir)
+    return sorted(out)
+
+
+def constraints_and_motion_from_seed(folder: str, dataset_folder: str, fps=FPS):
+    """Load seed_motion.json and BVH from folder; subsample to fps, convert to SOMA gt_motion.npz
+    and constraints."""
+    folder = Path(folder)
+    dataset_folder = Path(dataset_folder)
+    out_path = folder / "gt_motion.npz"
+
+    seed_motion = load_json(folder / "seed_motion.json")
+
+    start = seed_motion["crop_start_frame_index"]
+    end = seed_motion["crop_end_frame_index"]
+
+    bvh_path = dataset_folder / seed_motion["bvh_path"].replace("BVH/", "bvh/")
+
+    local_rot_mats, root_trans, bvh_fps = parse_bvh_motion(bvh_path)
+    step = round(bvh_fps / fps)
+
+    # Subsample fps
+    root_trans = root_trans[::step]
+    local_rot_mats = local_rot_mats[::step]
+
+    skeleton = SOMASkeleton77()
+    # Changing t_pose: essential step
+    local_rot_mats, global_rot_mats = skeleton.to_standard_tpose(local_rot_mats)
+
+    # Use the motion rep to canonicalize the motion (start z+ at 0,0)
+    # and get other components (smooth root, foot contacts etc)
+    motion_rep = KimodoMotionRep(skeleton, fps)
+    feats = motion_rep(local_rot_mats, root_trans, to_normalize=False)
+
+    # Crop the features and canonicalizing them
+    feats = feats[start:end]
+    can_feats = motion_rep.canonicalize(feats)
+    # Get back the motion
+    motion = motion_rep.inverse(can_feats, is_normalized=False)
+    motion = to_numpy(to_torch(motion, dtype=torch.float32))
+
+    np.savez(out_path, **motion)
+
+    seed_constraints_path = folder / "seed_constraints.json"
+    if seed_constraints_path.exists():
+        seed_constraints_lst = load_json(seed_constraints_path)
+
+        constraints_lst = []
+        for seed_cons in seed_constraints_lst:
+            cons = seed_cons.copy()
+            frame_indices = cons["frame_indices"]
+
+            cons["smooth_root_2d"] = motion["smooth_root_pos"][frame_indices][..., [0, 2]].tolist()
+
+            if cons["type"] == "root2d":
+                if cons.get("use_global_orient", False):
+                    cons["global_root_heading"] = motion["global_root_heading"][  # noqa
+                        frame_indices
+                    ].tolist()
+            elif cons["type"] in ["fullbody"] or cons["type"] in [
+                "left-hand",
+                "right-hand",
+                "left-foot",
+                "right-foot",
+                "end-effector",
+            ]:
+                cons["local_joints_rot"] = matrix_to_axis_angle(
+                    to_torch(motion["local_rot_mats"][frame_indices])
+                ).tolist()
+                cons["root_positions"] = motion["root_positions"][frame_indices].tolist()
+            else:
+                raise TypeError(f"This constraint type is not recognized: {cons['type']}")
+
+            constraints_lst.append(cons)
+
+        # check that it is close to old_constraints_lst
+        save_json(folder / "constraints.json", constraints_lst)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Recursively find test case to fill with motions and constraints.",
+    )
+    parser.add_argument(
+        "benchmark",
+        type=Path,
+        help="Root folder to search recursively or seed_motion.json for to download the benchmark testsuite from HuggingFace to.",
+    )
+    parser.add_argument(
+        "--dataset",
+        type=Path,
+        default="datasets/bones-seed/soma_uniform",
+        help="SEED dataset folder",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Redo the process even if gt_motion.npz already exists",
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=1,
+        help="Number of parallel worker processes (default: 1, sequential)",
+    )
+    args = parser.parse_args()
+
+    folder = args.benchmark.resolve()
+    if not folder.is_dir():
+        print(f"Benchmark folder not found at {folder}, downloading from HuggingFace...")
+        download_benchmark(folder)
+
+    dirs = discover_seed_motion_folders(folder)
+    if not dirs:
+        raise SystemExit(f"No directories with seed_motion.json found under {folder}")
+    print(f"Discovered {len(dirs)} motion to populate.")
+
+    skipped = 0
+    to_process = []
+    for d in dirs:
+        if not args.overwrite and (d / "gt_motion.npz").is_file():
+            skipped += 1
+        else:
+            to_process.append(d)
+
+    fn = partial(constraints_and_motion_from_seed, dataset_folder=args.dataset)
+    with Pool(args.workers) as pool:
+        list(tqdm(pool.imap_unordered(fn, to_process), total=len(to_process), desc="Extracting GT motions"))
+
+    if skipped:
+        print(f"Processed {len(dirs) - skipped} folders, skipped {skipped} (already present).")
+    else:
+        print("Saved gt_motion.npz and constraints.json from the seed files.")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/embed_folder.py
+++ b/benchmark/embed_folder.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Step (3) of evaluation pipeline.
+
+This script recursively embeds generated motions, ground-truth motions, and text prompts from a test suite folder tree with the pre-trained TMR model.
+"""
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import torch
+from tqdm import tqdm
+
+from kimodo.meta import parse_prompts_from_meta
+from kimodo.model.load_model import load_model
+from kimodo.tools import load_json
+
+
+def discover_motion_folders(root: Path) -> list[Path]:
+    root = root.resolve()
+    if not root.is_dir():
+        raise FileNotFoundError(f"Folder does not exist: {root}")
+    out: list[Path] = []
+    for meta_path in root.rglob("meta.json"):
+        src_dir = meta_path.parent
+        if (src_dir / "motion.npz").is_file() or (src_dir / "gt_motion.npz").is_file():
+            out.append(src_dir)
+    return sorted(out)
+
+
+def _load_posed_joints(npz_path: Path, device: str) -> torch.Tensor:
+    data = np.load(npz_path)
+    if "posed_joints" not in data:
+        raise SystemExit(f"NPZ must contain 'posed_joints': {npz_path}")
+    posed_joints = data["posed_joints"]
+    if posed_joints.ndim == 4:
+        if posed_joints.shape[0] != 1:
+            raise SystemExit(f"Expected batch size 1 for posed_joints, got {posed_joints.shape[0]} in {npz_path}")
+        posed_joints = posed_joints[0]
+    if posed_joints.ndim != 3:
+        raise SystemExit(f"Expected posed_joints shape [T, J, 3], got {posed_joints.shape} in {npz_path}")
+    return torch.from_numpy(posed_joints).float().to(device)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Recursively embed motion, gt_motion, and text; save motion_embedding.npy, gt_motion_embedding.npy, and text_embedding.npy when present.",
+    )
+    parser.add_argument(
+        "folder",
+        type=Path,
+        help="Root folder to search recursively for meta.json and motion.npz and/or gt_motion.npz",
+    )
+    parser.add_argument(
+        "--model",
+        default="tmr-soma-rp",
+        help="Model for encoding (e.g. TMR-SOMA-RP-v1, tmr-soma-rp). Default: tmr-soma-rp",
+    )
+    parser.add_argument(
+        "--device",
+        default=None,
+        help="Device (default: cuda if available else cpu)",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Re-embed even if embedding files already exist",
+    )
+    parser.add_argument(
+        "--text_encoder_fp32",
+        action="store_true",
+        help="Uses fp32 for the text encoder rather than default bfloat16.",
+    )
+    args = parser.parse_args()
+
+    folder = args.folder.resolve()
+    if not folder.is_dir():
+        raise SystemExit(f"Folder does not exist or is not a directory: {folder}")
+
+    device = args.device or ("cuda" if torch.cuda.is_available() else "cpu")
+    model = load_model(modelname=args.model, device=device, default_family="TMR", text_encoder_fp32=args.text_encoder_fp32)
+
+    dirs = discover_motion_folders(folder)
+    if not dirs:
+        raise SystemExit(f"No directories with meta.json and (motion.npz or gt_motion.npz) found under {folder}")
+    print(f"Discovered {len(dirs)} motion folders.")
+
+    skipped_motion = 0
+    skipped_gt = 0
+    skipped_text = 0
+    for sample_dir in tqdm(dirs, desc="Embedding"):
+        meta_path = sample_dir / "meta.json"
+        meta = load_json(meta_path)
+        texts, _ = parse_prompts_from_meta(meta)
+        if len(texts) != 1:
+            raise SystemExit(f"Expected exactly one text per motion; got {len(texts)} in {meta_path}")
+        text = texts[0]
+
+        # Embed motion.npz -> motion_embedding.npy
+        if (sample_dir / "motion.npz").is_file():
+            if not args.overwrite and (sample_dir / "motion_embedding.npy").is_file():
+                skipped_motion += 1
+            else:
+                npz_path = sample_dir / "motion.npz"
+                posed_joints = _load_posed_joints(npz_path, device)
+                with torch.inference_mode():
+                    motion_emb = model.encode_motion(posed_joints, unit_vector=True)
+                np.save(sample_dir / "motion_embedding.npy", motion_emb.cpu().numpy())
+
+        # Embed gt_motion.npz -> gt_motion_embedding.npy
+        if (sample_dir / "gt_motion.npz").is_file():
+            if not args.overwrite and (sample_dir / "gt_motion_embedding.npy").is_file():
+                skipped_gt += 1
+            else:
+                npz_path = sample_dir / "gt_motion.npz"
+                posed_joints = _load_posed_joints(npz_path, device)
+                with torch.inference_mode():
+                    gt_motion_emb = model.encode_motion(posed_joints, unit_vector=True)
+                np.save(sample_dir / "gt_motion_embedding.npy", gt_motion_emb.cpu().numpy())
+
+        # Embed text -> text_embedding.npy
+        if not args.overwrite and (sample_dir / "text_embedding.npy").is_file():
+            skipped_text += 1
+        else:
+            with torch.inference_mode():
+                text_emb = model.encode_raw_text([text], unit_vector=True)
+            np.save(sample_dir / "text_embedding.npy", text_emb.cpu().numpy())
+
+    total_skipped = skipped_motion + skipped_gt + skipped_text
+    if total_skipped:
+        print(f"Embedded {len(dirs)} folders; skipped some existing files (use --overwrite to re-embed).")
+    else:
+        print(f"Saved motion_embedding.npy, gt_motion_embedding.npy, and text_embedding.npy in {len(dirs)} folders.")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/evaluate_folder.py
+++ b/benchmark/evaluate_folder.py
@@ -1,0 +1,359 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Step (4) of evaluation pipeline.
+
+This script recursively computes metrics for generated and ground-truth motions within a test suite folder tree. 
+Saves metrics json files per test case and per group of test cases in the folder tree.
+"""
+
+import argparse
+import json
+from itertools import groupby
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from tqdm import tqdm
+
+from kimodo.constraints import load_constraints_lst
+from kimodo.meta import parse_prompts_from_meta
+from kimodo.metrics import (
+    ContraintFollow,
+    FootContactConsistency,
+    FootSkateFromContacts,
+    FootSkateFromHeight,
+    FootSkateRatio,
+    TMR_EmbeddingMetric,
+    aggregate_metrics,
+    clear_metrics,
+    compute_metrics,
+    compute_tmr_per_sample_retrieval,
+)
+from kimodo.skeleton import build_skeleton
+from kimodo.skeleton.definitions import SOMASkeleton30
+from kimodo.tools import load_json, to_torch
+
+DEFAULT_FPS = 30.0
+
+
+def discover_motion_folders(root: Path) -> list[tuple[Path, Path]]:
+    root = root.resolve()
+    if not root.is_dir():
+        raise FileNotFoundError(f"Folder does not exist: {root}")
+    out: list[tuple[Path, Path]] = []
+    for meta_path in root.rglob("meta.json"):
+        sample_dir = meta_path.parent
+        if (sample_dir / "motion.npz").is_file() and (sample_dir / "gt_motion.npz").is_file():
+            rel = sample_dir.relative_to(root)
+            out.append((sample_dir, rel))
+    return sorted(out, key=lambda x: str(x[1]))
+
+
+def group_by_parent(examples: list[tuple[Path, Path]]) -> list[list[tuple[Path, Path]]]:
+    def parent_key(item: tuple[Path, Path]) -> Path:
+        return item[1].parent if len(item[1].parts) > 1 else Path(".")
+
+    sorted_examples = sorted(examples, key=parent_key)
+    groups: list[list[tuple[Path, Path]]] = []
+    for _key, group in groupby(sorted_examples, key=parent_key):
+        groups.append(list(group))
+    return groups
+
+
+def _to_scalar(t: torch.Tensor) -> float:
+    return float(t.mean().item()) if t.numel() > 0 else float(t.item())
+
+
+def _to_p95(t: torch.Tensor) -> float:
+    if t.numel() == 0:
+        return float("nan")
+    return float(torch.nanquantile(t, torch.tensor(0.95, device=t.device), dim=0).item())
+
+
+def _per_sample_metrics_from_saved(metrics_list: list, n: int) -> list[dict[str, float]]:
+    per_sample: list[dict[str, float]] = [{} for _ in range(n)]
+    for metric in metrics_list:
+        for key, lst in metric.saved_metrics.items():
+            for i, t in enumerate(lst):
+                if i >= n:
+                    break
+                per_sample[i][key] = _to_scalar(t)
+    return per_sample
+
+
+def _load_pair_embeddings(
+    sample_dir: Path,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray | None] | None:
+    motion_emb_path = sample_dir / "motion_embedding.npy"
+    text_emb_path = sample_dir / "text_embedding.npy"
+    gt_motion_emb_path = sample_dir / "gt_motion_embedding.npy"
+    if not (motion_emb_path.is_file() and text_emb_path.is_file()):
+        return None
+
+    motion_emb = np.load(motion_emb_path)
+    text_emb = np.load(text_emb_path)
+    if motion_emb.ndim == 3 and motion_emb.shape[0] == 1:
+        motion_emb = motion_emb[0]
+    if text_emb.ndim == 3 and text_emb.shape[0] == 1:
+        text_emb = text_emb[0]
+
+    gt_motion_emb = None
+    if gt_motion_emb_path.is_file():
+        gt_motion_emb = np.load(gt_motion_emb_path)
+        if gt_motion_emb.ndim == 3 and gt_motion_emb.shape[0] == 1:
+            gt_motion_emb = gt_motion_emb[0]
+
+    return motion_emb, text_emb, gt_motion_emb
+
+
+def _load_npz_motion(
+    npz_path: Path,
+    device: str,
+    soma30_skel: SOMASkeleton30 | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Load posed_joints and foot_contacts from an NPZ, upscaling SOMA30 to SOMA77 if needed."""
+    data = np.load(npz_path)
+    posed_joints = to_torch(data["posed_joints"], device=device)
+    foot_contacts = to_torch(data["foot_contacts"], device=device)
+
+    if posed_joints.shape[-2] == 30 and soma30_skel is not None:
+        local_rot_mats = to_torch(data["local_rot_mats"], device=device)
+        root_positions = to_torch(data["root_positions"], device=device)
+        out77 = soma30_skel.output_to_SOMASkeleton77(
+            {"local_rot_mats": local_rot_mats, "root_positions": root_positions, "foot_contacts": foot_contacts}
+        )
+        posed_joints = out77["posed_joints"]
+        foot_contacts = out77["foot_contacts"]
+
+    return posed_joints, foot_contacts
+
+
+def _run_eval_on_group(
+    group: list[tuple[Path, Path]],
+    skeleton: torch.nn.Module,
+    metrics_list: list,
+    device: str,
+    group_name: str = "",
+    soma30_skel: SOMASkeleton30 | None = None,
+) -> tuple[
+    list[dict[str, float]],
+    list[dict[str, float]],
+    dict[str, float],
+    dict[str, float],
+    dict[str, float],
+    list[dict[str, Any]],
+]:
+    """Run two passes: gen (motion.npz + embeddings) and GT (gt_motion.npz only). Return
+    per_sample_gen, per_sample_gt, aggregated_gen, aggregated_gt, tmr_metrics, tmr_per_sample.
+    """
+    n = len(group)
+    sample_ids: list[str] = []
+    texts: list[str] = []
+    motion_embs: list[np.ndarray] = []
+    text_embs: list[np.ndarray] = []
+
+    # ----- Pass 1: generation (motion.npz + all embeddings) -----
+    clear_metrics(metrics_list)
+    desc = f"Samples ({group_name})" if group_name else "Samples"
+    for sample_dir, rel_path in tqdm(group, desc=desc, unit="motion"):
+        stem = rel_path.name
+        sample_ids.append(stem)
+        meta_path = sample_dir / "meta.json"
+        meta = load_json(meta_path)
+        texts_parsed, _ = parse_prompts_from_meta(meta)
+        texts.append(texts_parsed[0] if texts_parsed else "")
+
+        posed_joints, foot_contacts = _load_npz_motion(sample_dir / "motion.npz", device, soma30_skel)
+        nframes = posed_joints.shape[0]
+        lengths = torch.tensor(nframes, dtype=torch.long, device=device)
+        constraints_path = sample_dir / "constraints.json"
+        constraints_lst = (
+            load_constraints_lst(str(constraints_path), skeleton=skeleton) if constraints_path.is_file() else []
+        )
+        metrics_in: dict[str, Any] = {
+            "posed_joints": posed_joints,
+            "foot_contacts": foot_contacts,
+            "lengths": lengths,
+            "constraints_lst": constraints_lst,
+        }
+        text_this = texts_parsed[0] if texts_parsed else ""
+        embs = _load_pair_embeddings(sample_dir)
+        if (text_this or "").strip() and embs is not None:
+            motion_emb, text_emb, gt_motion_emb = embs
+            metrics_in["motion_emb"] = motion_emb
+            metrics_in["text_emb"] = text_emb
+            if gt_motion_emb is not None:
+                metrics_in["gt_motion_emb"] = gt_motion_emb
+            motion_embs.append(motion_emb)
+            text_embs.append(text_emb)
+
+        compute_metrics(metrics_list, metrics_in)
+
+    per_sample_gen = _per_sample_metrics_from_saved(metrics_list, n)
+    raw_aggregated_gen = aggregate_metrics(metrics_list)
+    aggregated_gen = {}
+    tmr_metrics: dict[str, float] = {}
+    has_text = len(motion_embs) == n and len(text_embs) == n
+    for key, v in raw_aggregated_gen.items():
+        val = _to_scalar(v)
+        if key.startswith("TMR/"):
+            if has_text:
+                tmr_metrics[key] = val
+        else:
+            aggregated_gen[key] = val
+    if "constraint_root2d_err" in raw_aggregated_gen:
+        aggregated_gen["constraint_root2d_err_p95"] = _to_p95(raw_aggregated_gen["constraint_root2d_err"])
+
+    tmr_per_sample: list[dict[str, Any]] = []
+    if has_text and motion_embs and text_embs and len(motion_embs) == n and len(text_embs) == n:
+        motion_emb_stack = np.stack(motion_embs, axis=0)
+        text_emb_stack = np.stack(text_embs, axis=0)
+        tmr_per_sample = compute_tmr_per_sample_retrieval(motion_emb_stack, text_emb_stack, sample_ids, texts, top_k=5)
+
+    # ----- Pass 2: GT (gt_motion.npz only, no embeddings) -----
+    clear_metrics(metrics_list)
+    for sample_dir, rel_path in tqdm(group, desc=f"GT ({group_name})" if group_name else "GT", unit="motion"):
+        posed_joints, foot_contacts = _load_npz_motion(sample_dir / "gt_motion.npz", device, soma30_skel)
+        nframes = posed_joints.shape[0]
+        lengths = torch.tensor(nframes, dtype=torch.long, device=device)
+        constraints_path = sample_dir / "constraints.json"
+        constraints_lst = (
+            load_constraints_lst(str(constraints_path), skeleton=skeleton) if constraints_path.is_file() else []
+        )
+        metrics_in = {
+            "posed_joints": posed_joints,
+            "foot_contacts": foot_contacts,
+            "lengths": lengths,
+            "constraints_lst": constraints_lst,
+        }
+        compute_metrics(metrics_list, metrics_in)
+
+    per_sample_gt = _per_sample_metrics_from_saved(metrics_list, n)
+    raw_aggregated_gt = aggregate_metrics(metrics_list)
+    aggregated_gt = {}
+    for key, v in raw_aggregated_gt.items():
+        if key.startswith("TMR/"):
+            continue
+        aggregated_gt[key] = _to_scalar(v)
+    if "constraint_root2d_err" in raw_aggregated_gt:
+        aggregated_gt["constraint_root2d_err_p95"] = _to_p95(raw_aggregated_gt["constraint_root2d_err"])
+
+    return (
+        per_sample_gen,
+        per_sample_gt,
+        aggregated_gen,
+        aggregated_gt,
+        tmr_metrics,
+        tmr_per_sample,
+    )
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Recursively evaluate generated motions; write metrics.json per folder and <name>.json per parent.",
+    )
+    parser.add_argument(
+        "folder",
+        type=Path,
+        help="Root folder to search recursively for meta.json + motion.npz + gt_motion.npz",
+    )
+    parser.add_argument("--device", default=None, help="cuda/cpu. Default: auto")
+    args = parser.parse_args()
+
+    folder = args.folder.resolve()
+    if not folder.is_dir():
+        raise SystemExit(f"Folder does not exist: {folder}")
+
+    device = args.device or ("cuda" if torch.cuda.is_available() else "cpu")
+
+    examples = discover_motion_folders(folder)
+    if not examples:
+        raise SystemExit(f"No directories with meta.json, motion.npz, and gt_motion.npz found under {folder}")
+    print(f"Discovered {len(examples)} motion folders.")
+
+    first_posed = np.load(examples[0][0] / "motion.npz")["posed_joints"]
+    num_joints = first_posed.shape[-2]
+
+    # SOMA models could generate 30-joint output; upscale to 77 for evaluation
+    soma30_skel: SOMASkeleton30 | None = None
+    if num_joints == 30:
+        soma30_skel = SOMASkeleton30().to(device)
+        _ = soma30_skel.somaskel77  # trigger lazy init
+        soma30_skel.somaskel77.to(device)
+        skeleton = soma30_skel.somaskel77
+        print("Detected SOMA30 motions; will upscale to SOMA77 for evaluation.")
+    else:
+        skeleton = build_skeleton(num_joints).to(device)
+
+    fps = DEFAULT_FPS
+    kwargs = {"skeleton": skeleton, "fps": fps}
+    metrics_list = [
+        FootSkateFromHeight(**kwargs),
+        FootSkateFromContacts(**kwargs),
+        FootContactConsistency(**kwargs),
+        FootSkateRatio(**kwargs),
+        ContraintFollow(**kwargs),
+        TMR_EmbeddingMetric(**kwargs),
+    ]
+
+    groups = group_by_parent(examples)
+    for group in tqdm(groups, desc="Evaluating folders"):
+        sample_dirs = [g[0] for g in group]
+        folder_for_group = sample_dirs[0].parent
+        folder_name = folder_for_group.name
+
+        (
+            per_sample_gen,
+            per_sample_gt,
+            aggregated_gen,
+            aggregated_gt,
+            tmr_metrics,
+            tmr_per_sample,
+        ) = _run_eval_on_group(group, skeleton, metrics_list, device, group_name=folder_name, soma30_skel=soma30_skel)
+
+        texts = []
+        for sample_dir, _ in group:
+            meta = load_json(sample_dir / "meta.json")
+            texts_parsed, _ = parse_prompts_from_meta(meta)
+            texts.append(texts_parsed[0] if texts_parsed else "")
+
+        for i, (sample_dir, _) in enumerate(group):
+            metrics_path = sample_dir / "metrics.json"
+            out = {
+                "num_motions": 1,
+                "folder": str(sample_dir),
+                "per_motion_mean_gen": per_sample_gen[i] if i < len(per_sample_gen) else {},
+                "per_motion_mean_gt": per_sample_gt[i] if i < len(per_sample_gt) else {},
+            }
+            if i < len(tmr_per_sample):
+                out["tmr"] = {
+                    "t2m_rank": tmr_per_sample[i]["rank"],
+                    "text": texts[i] if i < len(texts) else "",
+                    "top5_retrieved": tmr_per_sample[i]["top_k"],
+                }
+            _write_json(metrics_path, out)
+
+        parent_json_path = folder_for_group.parent / f"{folder_name}.json"
+        full_metrics = {
+            "num_motions": len(group),
+            "folder": str(folder_for_group),
+            "per_motion_mean_gen": aggregated_gen,
+            "per_motion_mean_gt": aggregated_gt,
+        }
+        if tmr_metrics:
+            full_metrics["tmr"] = tmr_metrics
+        _write_json(parent_json_path, full_metrics)
+
+    print(f"Wrote metrics.json in each of {len(examples)} folders and folder-level JSONs for {len(groups)} groups.")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/generate_eval.py
+++ b/benchmark/generate_eval.py
@@ -1,0 +1,382 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Step (2) of evaluation pipeline.
+
+This script recursively generates motions using Kimodo from a test suite folder tree.
+"""
+
+import argparse
+import shutil
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from torch.utils.data import DataLoader, Dataset
+from tqdm.auto import tqdm
+
+from kimodo.constraints import load_constraints_lst
+from kimodo.meta import parse_prompts_from_meta
+from kimodo.model import DEFAULT_MODEL, load_model
+from kimodo.tools import load_json, seed_everything
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Recursively generate motions from a testsuite folder tree")
+    parser.add_argument(
+        "--benchmark",
+        type=str,
+        default="testsuite",
+        help="Root folder containing subfolders with meta.json (default: testsuite)",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="Output root; directory hierarchy is mirrored here. If omitted, motions are generated in-place inside the testsuite folder.",
+    )
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        default=32,
+        help="Batch size for generating motions (default: 32)",
+    )
+    parser.add_argument(
+        "--num_workers",
+        type=int,
+        default=4,
+        help="DataLoader workers for loading meta/constraints paths (default: 4)",
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default=DEFAULT_MODEL,
+        help="Name of the model (e.g. Kimodo-SOMA-RP-v1.1, kimodo-soma-rp, or SOMA).",
+    )
+    parser.add_argument(
+        "--diffusion_steps",
+        type=int,
+        default=100,
+        help="Number of diffusion steps (default: 100); overridden by meta.json if present",
+    )
+    parser.add_argument(
+        "--postprocess",
+        action="store_true",
+        help="Apply motion post-processing to reduce foot skating",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Regenerate outputs even if motion.npz already exists",
+    )
+    parser.add_argument(
+        "--text_encoder_fp32",
+        action="store_true",
+        help="Uses fp32 for instantiating the text encoder (if API is not already running) rather than default bfloat16.",
+    )
+    return parser.parse_args()
+
+
+def discover_example_folders(root: Path) -> list[tuple[Path, Path]]:
+    """Discover leaf directories that contain meta.json.
+
+    Returns list of (src_dir, rel_path).
+    """
+    root = root.resolve()
+    if not root.is_dir():
+        raise FileNotFoundError(f"Testsuite folder does not exist: {root}")
+    out: list[tuple[Path, Path]] = []
+    for meta_path in root.rglob("meta.json"):
+        src_dir = meta_path.parent
+        rel = src_dir.relative_to(root)
+        out.append((src_dir, rel))
+    return sorted(out, key=lambda x: str(x[1]))
+
+
+def copy_source_files(src_dir: Path, out_dir: Path) -> None:
+    """Copy meta.json, constraints.json, and gt_motion.npz (if present) from src_dir to out_dir."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for name in ("meta.json", "constraints.json", "gt_motion.npz"):
+        src_file = src_dir / name
+        if src_file.is_file():
+            shutil.copy2(src_file, out_dir / name)
+
+
+class EvalExampleDataset(Dataset):
+    """Dataset of example folders: yields text, num_frame, constraints_path (and paths, meta).
+    No torch/skeleton in workers so num_workers > 0 is safe with CUDA.
+    """
+
+    def __init__(
+        self,
+        examples: list[tuple[Path, Path]],
+        testsuite_root: Path,
+        generated_root: Path,
+        fps: float,
+    ):
+        self.examples = examples
+        self.testsuite_root = testsuite_root
+        self.generated_root = generated_root
+        self.fps = fps
+
+    def __len__(self) -> int:
+        return len(self.examples)
+
+    def __getitem__(self, idx: int) -> dict[str, Any]:
+        src_dir, rel_path = self.examples[idx]
+        out_dir = self.generated_root / rel_path
+        meta_path = src_dir / "meta.json"
+        meta = load_json(str(meta_path))
+        assert meta.get("num_samples", 1) == 1, "Expected num_samples to be absent or 1 in meta.json"
+        texts, durations_sec = parse_prompts_from_meta(meta)
+        assert len(texts) == 1, "Expected exactly one prompt (len(texts)==1) per example"
+        num_frames = [int(float(d) * self.fps) for d in durations_sec]
+        assert len(num_frames) == 1, "Expected exactly one duration per example"
+        constraints_path = src_dir / "constraints.json"
+        cpath = str(constraints_path) if constraints_path.is_file() else None
+        return {
+            "rel_path": rel_path,
+            "src_dir": str(src_dir),
+            "out_dir": str(out_dir),
+            "meta": meta,
+            "text": texts[0],
+            "num_frame": num_frames[0],
+            "constraints_path": cpath,
+        }
+
+
+def collate_examples(batch: list[dict]) -> dict[str, Any]:
+    """Collate list of example dicts; keep list fields as lists (no stacking)."""
+    if not batch:
+        return {}
+    keys = batch[0].keys()
+    out: dict[str, Any] = {}
+    for k in keys:
+        vals = [b[k] for b in batch]
+        out[k] = vals
+    return out
+
+
+def group_by_parent(
+    examples: list[tuple[Path, Path]],
+) -> list[list[tuple[Path, Path]]]:
+    """Group (src_dir, rel_path) by parent directory of rel_path for folder-by-folder processing."""
+    from itertools import groupby
+
+    def parent_key(item: tuple[Path, Path]) -> Path:
+        rel = item[1]
+        return rel.parent if len(rel.parts) > 1 else Path(".")
+
+    sorted_examples = sorted(examples, key=parent_key)
+    groups: list[list[tuple[Path, Path]]] = []
+    for _key, group in groupby(sorted_examples, key=parent_key):
+        groups.append(list(group))
+    return groups
+
+
+def _slice_output_at(output: dict[str, Any], index: int) -> dict[str, Any]:
+    """Slice a (possibly nested) output dict at batch index for one sample."""
+    out: dict[str, Any] = {}
+    for k, v in output.items():
+        if isinstance(v, dict):
+            out[k] = _slice_output_at(v, index)
+        elif isinstance(v, np.ndarray) and v.ndim > 0:
+            out[k] = v[index]
+        else:
+            out[k] = v
+    return out
+
+
+def _crop_output(output: dict[str, Any], num_frames: int) -> dict[str, Any]:
+    """Crop a single-sample output dict along the time dimension (axis 0)."""
+    out: dict[str, Any] = {}
+    for k, v in output.items():
+        if isinstance(v, dict):
+            out[k] = _crop_output(v, num_frames)
+        elif isinstance(v, np.ndarray) and v.ndim >= 1:
+            out[k] = v[:num_frames]
+        else:
+            out[k] = v
+    return out
+
+
+def main():
+    device = "cuda:0" if torch.cuda.is_available() else "cpu"
+    print(f"Using device: {device}")
+
+    args = parse_args()
+    testsuite_root = Path(args.benchmark).resolve()
+    if args.output is not None:
+        generated_root = Path(args.output).resolve()
+    else:
+        generated_root = testsuite_root
+    in_place = generated_root == testsuite_root
+
+    examples = discover_example_folders(testsuite_root)
+    if not examples:
+        raise SystemExit(f"No folders with meta.json found under {testsuite_root}")
+    print(f"Discovered {len(examples)} example folders.")
+
+    model, resolved_name = load_model(
+        args.model,
+        device=device,
+        default_family="Kimodo",
+        return_resolved_name=True,
+        text_encoder_fp32=args.text_encoder_fp32,
+    )
+    # v1.1 models are meant to be used for benchmark evaluation
+    _deprecated_for_benchmark = {
+        "kimodo-soma-rp-v1": "Kimodo-SOMA-RP-v1 was not trained to be compatible with the benchmark evaluation.",
+        "kimodo-soma-seed-v1": "Kimodo-SOMA-SEED-v1 is not the latest model for benchmark evaluation.",
+    }
+    if resolved_name in _deprecated_for_benchmark:
+        import warnings
+
+        warnings.warn(
+            f"Model '{args.model}' resolved to {resolved_name}: "
+            f"{_deprecated_for_benchmark[resolved_name]} Consider using v1.1.",
+            stacklevel=1,
+        )
+    print(f"Generating with model: {resolved_name}")
+    fps = model.fps
+    default_diffusion_steps = args.diffusion_steps
+
+    groups = group_by_parent(examples)
+    total_generated = 0
+    total_skipped = 0
+
+    total_examples = len(examples)
+    for group in groups:
+        rel_path_0 = group[0][1]
+        if rel_path_0.parent != Path("."):
+            folder_label = str(rel_path_0.parent)
+        else:
+            # Direct children of testsuite root: show root name (e.g. inbetweening)
+            folder_label = testsuite_root.name
+        num_in_folder = len(group)
+        print(f"Generating folder: {folder_label} ({num_in_folder} motions)")
+
+        dataset = EvalExampleDataset(
+            group,
+            testsuite_root,
+            generated_root,
+            fps=fps,
+        )
+        loader = DataLoader(
+            dataset,
+            batch_size=args.batch_size,
+            shuffle=False,
+            num_workers=args.num_workers,
+            collate_fn=collate_examples,
+        )
+
+        folder_generated = 0
+        folder_skipped = 0
+        for batch_idx, batch in enumerate(loader):
+            rel_paths = batch["rel_path"]
+            src_dirs = batch["src_dir"]
+            out_dirs = batch["out_dir"]
+            metas = batch["meta"]
+            batch_texts = batch["text"]
+            batch_num_frames = batch["num_frame"]
+            constraints_paths = batch["constraints_path"]
+
+            # Filter out samples that are already generated (unless --overwrite).
+            if args.overwrite:
+                selected_indices = list(range(len(rel_paths)))
+            else:
+                selected_indices = []
+                for i, out_dir_str in enumerate(out_dirs):
+                    motion_path = Path(out_dir_str) / "motion.npz"
+                    if motion_path.is_file():
+                        folder_skipped += 1
+                        total_skipped += 1
+                        continue
+                    selected_indices.append(i)
+
+            if not selected_indices:
+                print(
+                    f"\r  Generated {folder_generated} / {num_in_folder} (skipped: {folder_skipped}) "
+                    f"(total: {total_generated + total_skipped} / {total_examples})",
+                    end="",
+                    flush=True,
+                )
+                continue
+
+            rel_paths = [rel_paths[i] for i in selected_indices]
+            src_dirs = [src_dirs[i] for i in selected_indices]
+            out_dirs = [out_dirs[i] for i in selected_indices]
+            metas = [metas[i] for i in selected_indices]
+            batch_texts = [batch_texts[i] for i in selected_indices]
+            batch_num_frames = [batch_num_frames[i] for i in selected_indices]
+            constraints_paths = [constraints_paths[i] for i in selected_indices]
+
+            # Load constraints in main process on model device (no torch in workers)
+            device_t = torch.device(device)
+            batch_constraints_lst = [
+                load_constraints_lst(cpath, model.skeleton, device=device_t) if cpath else []
+                for cpath in constraints_paths
+            ]
+
+            if not in_place:
+                for i in range(len(rel_paths)):
+                    copy_source_files(Path(src_dirs[i]), Path(out_dirs[i]))
+
+            # Use first example's diffusion_steps and seed for the whole batch
+            diffusion_steps = metas[0].get("diffusion_steps", default_diffusion_steps)
+            seed = metas[0].get("seed", None)
+            if seed is not None:
+                seed_everything(seed)
+            else:
+                print("Warning: No seed found in meta.json, not seeding this batch.")
+
+            # Single model call for the entire batch (count in bar title, bar clears when done)
+            bar_desc = (
+                f"  Generated {folder_generated} / {num_in_folder} "
+                f"(skipped: {folder_skipped}) (total: {total_generated + total_skipped} / {total_examples})"
+            )
+            output = model(
+                batch_texts,
+                batch_num_frames,
+                constraint_lst=batch_constraints_lst,
+                num_denoising_steps=diffusion_steps,
+                multi_prompt=False,
+                post_processing=args.postprocess,
+                return_numpy=True,
+                progress_bar=lambda x: tqdm(x, leave=False, desc=bar_desc),
+            )
+
+            # Save each sample to its output dir
+            B = len(batch_texts)
+            for b in range(B):
+                out_dir = Path(out_dirs[b])
+                sample_output = _slice_output_at(output, b)
+                sample_output = _crop_output(sample_output, batch_num_frames[b])
+                motion_path = out_dir / "motion.npz"
+                np.savez(motion_path, **sample_output)
+                total_generated += 1
+                folder_generated += 1
+
+            print(
+                f"\r  Generated {folder_generated} / {num_in_folder} (skipped: {folder_skipped}) "
+                f"(total: {total_generated + total_skipped} / {total_examples})",
+                end="",
+                flush=True,
+            )
+
+        print()
+        print(
+            f"  Finished folder {folder_label} ({num_in_folder} motions, "
+            f"generated: {folder_generated}, skipped: {folder_skipped})."
+        )
+
+    if in_place:
+        print(f"Generated {total_generated} motions in-place under {testsuite_root}.")
+    else:
+        print(f"Generated {total_generated} motions under {generated_root}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/parse_folder.py
+++ b/benchmark/parse_folder.py
@@ -1,0 +1,686 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Step (5) of evaluation pipeline.
+
+Validate testcase result JSONs and aggregate benchmark rows.
+
+Expected testsuite layout (aligned with evaluate_folder output):
+
+    <root>/
+    ├── <split>/                    # e.g. content, repetition
+    │   ├── text2motion/            # text-following eval
+    │   │   ├── overview/           # or timeline_single, timeline_multi
+    │   │   │   └── <testcase>.json
+    │   │   └── ...
+    │   └── <category>/             # constraints_withtext, constraints_notext
+    │       └── .../                 # optional subdirs, e.g. root, fullbody
+    │           └── <testcase>/
+    │           └── <testcase>.json
+
+Samples are discovered via rglob('meta.json') with motion.npz and gt_motion.npz in the same dir.
+Testcase dir = parent of a sample dir. Result file = testcase_dir.parent / f"{testcase_dir.name}.json".
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+SPLITS = ("content", "repetition")
+TEXT_FOLLOWING_CATEGORIES = ("overview", "timeline_single", "timeline_multi")
+CONSTRAINTS_CATEGORIES = ("constraints_withtext", "constraints_notext")
+ROW_CATEGORIES = TEXT_FOLLOWING_CATEGORIES + CONSTRAINTS_CATEGORIES
+
+
+def _discover_sample_dirs(root: Path) -> list[Path]:
+    sample_dirs: list[Path] = []
+    for meta_path in root.rglob("meta.json"):
+        sample_dir = meta_path.parent
+        if (sample_dir / "motion.npz").is_file() and (sample_dir / "gt_motion.npz").is_file():
+            sample_dirs.append(sample_dir)
+    return sorted(set(sample_dirs))
+
+
+def _discover_testcase_dirs(root: Path) -> list[Path]:
+    sample_dirs = _discover_sample_dirs(root)
+    return sorted({sample_dir.parent for sample_dir in sample_dirs})
+
+
+def _expected_result_path(testcase_dir: Path) -> Path:
+    return testcase_dir.parent / f"{testcase_dir.name}.json"
+
+
+def _parse_testcase_key(root: Path, testcase_dir: Path) -> tuple[str, str]:
+    rel_parts = testcase_dir.relative_to(root).parts
+    if len(rel_parts) < 2:
+        raise ValueError(f"Unexpected testcase path shape: {testcase_dir} (relative: {'/'.join(rel_parts)})")
+    split = rel_parts[0]
+    if split not in SPLITS:
+        raise ValueError(f"Unknown split '{split}' for testcase {testcase_dir}")
+    if len(rel_parts) >= 3 and rel_parts[1] == "text2motion":
+        category = rel_parts[2]
+        if category not in TEXT_FOLLOWING_CATEGORIES:
+            raise ValueError(f"Unknown text-following category '{category}' for testcase {testcase_dir}")
+    else:
+        category = rel_parts[1]
+        if category not in CONSTRAINTS_CATEGORIES:
+            raise ValueError(f"Unknown category '{category}' for testcase {testcase_dir}")
+    return split, category
+
+
+def _accumulate_weighted(acc: dict[str, float], metric_dict: dict[str, Any], weight: float) -> None:
+    for metric_name, value in metric_dict.items():
+        if isinstance(value, (int, float)):
+            acc[metric_name] = acc.get(metric_name, 0.0) + float(value) * weight
+
+
+def _to_averages(weighted_sum: dict[str, float], total_weight: float) -> dict[str, float]:
+    if total_weight <= 0:
+        return {}
+    return {k: v / total_weight for k, v in sorted(weighted_sum.items())}
+
+
+def _load_result_row(
+    result_path: Path,
+) -> tuple[float, dict[str, Any], dict[str, Any], dict[str, Any]]:
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    num_motions = float(payload.get("num_motions", 1))
+    per_motion_mean_gen = payload.get("per_motion_mean_gen") or payload.get("per_motion_mean", {})
+    per_motion_mean_gt = payload.get("per_motion_mean_gt") or {}
+    tmr = payload.get("tmr") or {}
+    if not isinstance(per_motion_mean_gen, dict):
+        raise ValueError(f"'per_motion_mean_gen' / 'per_motion_mean' is not a dict in {result_path}")
+    if not isinstance(per_motion_mean_gt, dict):
+        raise ValueError(f"'per_motion_mean_gt' is not a dict in {result_path}")
+    if not isinstance(tmr, dict):
+        raise ValueError(f"'tmr' is not a dict in {result_path}")
+    return num_motions, per_motion_mean_gen, per_motion_mean_gt, tmr
+
+
+# Display labels for table rows (paper-style).
+TEXT_FOLLOWING_ROW_LABELS = {
+    "overview": "Overview",
+    "timeline_single": "Timeline single",
+    "timeline_multi": "Timeline multi",
+}
+CONSTRAINTS_ROW_LABELS = {
+    "constraints_withtext": "Constraints with text",
+    "constraints_notext": "Constraints without text",
+}
+
+# Meters to cm for constraint position metrics.
+M_TO_CM = 100.0
+
+
+def _table_value(val: float | None) -> float | str | None:
+    """Return value for JSON table; use None for missing (omit or serialize as null)."""
+    if val is None:
+        return None
+    if isinstance(val, (int, float)) and (val != val or val == float("inf")):  # nan or inf
+        return None
+    return val
+
+
+def _build_tables(
+    row_acc: dict[tuple[str, str], dict[str, Any]],
+) -> dict[str, dict[str, list[dict[str, Any]]]]:
+    """Build text_following and constraints tables per split for paper-style output."""
+    tables: dict[str, dict[str, list[dict[str, Any]]]] = {}
+    for split in SPLITS:
+        tables[split] = {"text_following": [], "constraints": []}
+
+        # Text-following table: Overview, Timeline single, Timeline multi.
+        for category in TEXT_FOLLOWING_CATEGORIES:
+            acc = row_acc[(split, category)]
+            per_motion_gen = _to_averages(acc["per_motion_mean_weighted_sum"], acc["num_motions"])
+            per_motion_gt = _to_averages(acc["per_motion_mean_gt_weighted_sum"], acc["num_motions"])
+            tmr_avg = _to_averages(acc["tmr_weighted_sum"], acc["tmr_weight"]) if acc["tmr_weight"] > 0 else {}
+            r03_gen = tmr_avg.get("TMR/t2m_R/R03")
+            r03_gt = tmr_avg.get("TMR/t2m_gt_R/R03")
+            fid_gen_text = tmr_avg.get("TMR/FID/gen_text")
+            fid_gt_text = tmr_avg.get("TMR/FID/gt_text")
+            fid_gen_gt = tmr_avg.get("TMR/FID/gen_gt")
+            # Skate is velocity in m/s; convert to cm/s for display.
+            skate_gen = per_motion_gen.get("foot_skate_from_pred_contacts")
+            skate_gt = per_motion_gt.get("foot_skate_from_pred_contacts")
+            contact_gen = per_motion_gen.get("foot_contact_consistency")
+            contact_gt = per_motion_gt.get("foot_contact_consistency")
+            row_label = TEXT_FOLLOWING_ROW_LABELS[category]
+            tables[split]["text_following"].append(
+                {
+                    "row": row_label,
+                    "R@3 (gen)": _table_value(r03_gen),
+                    "R@3 (GT)": _table_value(r03_gt),
+                    "FID gen-text": _table_value(fid_gen_text),
+                    "FID GT-text": _table_value(fid_gt_text),
+                    "FID gen-GT": _table_value(fid_gen_gt),
+                    "Skate (gen, cm/s)": _table_value(skate_gen * 100.0 if skate_gen is not None else None),
+                    "Skate (GT, cm/s)": _table_value(skate_gt * 100.0 if skate_gt is not None else None),
+                    "Contact (gen)": _table_value(contact_gen),
+                    "Contact (GT)": _table_value(contact_gt),
+                }
+            )
+
+        # Constraints table: Constraints with text, Constraints without text.
+        for category in CONSTRAINTS_CATEGORIES:
+            acc = row_acc[(split, category)]
+            per_motion_gen = _to_averages(acc["per_motion_mean_weighted_sum"], acc["num_motions"])
+            per_motion_gt = _to_averages(acc["per_motion_mean_gt_weighted_sum"], acc["num_motions"])
+            row_label = CONSTRAINTS_ROW_LABELS[category]
+            row_dict: dict[str, Any] = {
+                "row": row_label,
+                "Full-Body Pos (gen, cm)": _table_value(
+                    per_motion_gen.get("constraint_fullbody_keyframe") * M_TO_CM
+                    if per_motion_gen.get("constraint_fullbody_keyframe") is not None
+                    else None
+                ),
+                "Full-Body Pos (GT, cm)": _table_value(
+                    per_motion_gt.get("constraint_fullbody_keyframe") * M_TO_CM
+                    if per_motion_gt.get("constraint_fullbody_keyframe") is not None
+                    else None
+                ),
+                "End-Effector Pos (gen, cm)": _table_value(
+                    per_motion_gen.get("constraint_end_effector") * M_TO_CM
+                    if per_motion_gen.get("constraint_end_effector") is not None
+                    else None
+                ),
+                "End-Effector Pos (GT, cm)": _table_value(
+                    per_motion_gt.get("constraint_end_effector") * M_TO_CM
+                    if per_motion_gt.get("constraint_end_effector") is not None
+                    else None
+                ),
+                "End-Effector Rot (deg)": None,  # Not implemented in metrics.
+                "2D Root Pos (gen, cm)": _table_value(
+                    per_motion_gen.get("constraint_root2d_err") * M_TO_CM
+                    if per_motion_gen.get("constraint_root2d_err") is not None
+                    else None
+                ),
+                "2D Root Pos (GT, cm)": _table_value(
+                    per_motion_gt.get("constraint_root2d_err") * M_TO_CM
+                    if per_motion_gt.get("constraint_root2d_err") is not None
+                    else None
+                ),
+                "2D Pelvis Pos@95% (gen, cm)": _table_value(
+                    per_motion_gen.get("constraint_root2d_err_p95") * M_TO_CM
+                    if per_motion_gen.get("constraint_root2d_err_p95") is not None
+                    else None
+                ),
+                "2D Pelvis Pos@95% (GT, cm)": _table_value(
+                    per_motion_gt.get("constraint_root2d_err_p95") * M_TO_CM
+                    if per_motion_gt.get("constraint_root2d_err_p95") is not None
+                    else None
+                ),
+            }
+            tables[split]["constraints"].append(row_dict)
+
+    return tables
+
+
+def _fmt_md(val: float | None, decimals: int) -> str:
+    """Format a numeric value for a markdown cell, or '-' for None/NaN."""
+    if val is None:
+        return "-"
+    if isinstance(val, float) and (val != val or val == float("inf")):
+        return "-"
+    return f"{val:.{decimals}f}"
+
+
+def _print_tf_formatted_md(
+    splits_data: list[tuple[str, list[dict[str, Any]]]],
+    title: str,
+) -> None:
+    """Print text-following table in markdown, mirroring the terminal layout."""
+    groups = ["Overview", "Timeline single", "Timeline multi"]
+    specs: list[tuple[str, int]] = [
+        ("R@3\u2191", 2),
+        ("FID\u2193", 3),
+        ("Skate\u2193", 3),
+        ("Contact\u2191", 3),
+    ]
+    gt_keys = ["R@3 (GT)", None, "Skate (GT, cm/s)", "Contact (GT)"]
+    gen_keys = ["R@3 (gen)", "FID gen-GT", "Skate (gen, cm/s)", "Contact (gen)"]
+    gt_defaults: list[float | None] = [None, 0.0, None, None]
+
+    headers = [""]
+    for g in groups:
+        for hdr, _ in specs:
+            headers.append(f"{g} {hdr}")
+
+    print(f"\n### {title}\n")
+    print("| " + " | ".join(headers) + " |")
+    print("| " + " | ".join("---" for _ in headers) + " |")
+
+    for split_label, rows in splits_data:
+        for row_type, keys, defaults in [
+            ("Ground Truth", gt_keys, gt_defaults),
+            ("Method", gen_keys, [None] * len(specs)),
+        ]:
+            cells = [f"**{split_label}** {row_type}"]
+            for row in rows:
+                for j, (_, dec) in enumerate(specs):
+                    key = keys[j]
+                    val = defaults[j] if key is None else row.get(key)
+                    cells.append(_fmt_md(val, dec))
+            print("| " + " | ".join(cells) + " |")
+
+    print()
+
+
+def _print_c_formatted_md(
+    splits_data: list[tuple[str, list[dict[str, Any]]]],
+    title: str,
+) -> None:
+    """Print constraints table in markdown, mirroring the terminal layout."""
+    groups = ["With text", "Without text"]
+    specs: list[tuple[str, int]] = [
+        ("FB Pos\u2193", 3),
+        ("EE Pos\u2193", 3),
+        ("EE Rot\u2193", 3),
+        ("2D Root\u2193", 3),
+        ("Pelvis@95%", 2),
+    ]
+    gt_keys = [
+        "Full-Body Pos (GT, cm)",
+        "End-Effector Pos (GT, cm)",
+        "End-Effector Rot (deg)",
+        "2D Root Pos (GT, cm)",
+        "2D Pelvis Pos@95% (GT, cm)",
+    ]
+    gen_keys = [
+        "Full-Body Pos (gen, cm)",
+        "End-Effector Pos (gen, cm)",
+        "End-Effector Rot (deg)",
+        "2D Root Pos (gen, cm)",
+        "2D Pelvis Pos@95% (gen, cm)",
+    ]
+
+    headers = [""]
+    for g in groups:
+        for hdr, _ in specs:
+            headers.append(f"{g} {hdr}")
+
+    print(f"\n### {title}\n")
+    print("| " + " | ".join(headers) + " |")
+    print("| " + " | ".join("---" for _ in headers) + " |")
+
+    for split_label, rows in splits_data:
+        for row_type, keys in [("Ground Truth", gt_keys), ("Method", gen_keys)]:
+            cells = [f"**{split_label}** {row_type}"]
+            for row in rows:
+                for j, (_, dec) in enumerate(specs):
+                    cells.append(_fmt_md(row.get(keys[j]), dec))
+            print("| " + " | ".join(cells) + " |")
+
+    print()
+
+
+def _print_formatted_gt_method_md(
+    tables: dict[str, dict[str, list[dict[str, Any]]]],
+) -> None:
+    """Print combined tables in markdown format, mirroring the terminal layout."""
+    tf_splits: list[tuple[str, list[dict[str, Any]]]] = []
+    c_splits: list[tuple[str, list[dict[str, Any]]]] = []
+    for split in SPLITS:
+        split_tables = tables.get(split, {})
+        tf_rows = split_tables.get("text_following", [])
+        c_rows = split_tables.get("constraints", [])
+        if tf_rows and len(tf_rows) == 3:
+            tf_splits.append((split.capitalize(), tf_rows))
+        if c_rows and len(c_rows) == 2:
+            c_splits.append((split.capitalize(), c_rows))
+
+    if tf_splits:
+        _print_tf_formatted_md(tf_splits, "Text-Following Evaluation")
+    if c_splits:
+        _print_c_formatted_md(c_splits, "Constrained Evaluation")
+
+
+def _fmt(val: float | None, decimals: int, width: int) -> str:
+    """Format a numeric value right-aligned to *width*, or '-' for None."""
+    if val is None:
+        return f"{'-':>{width}}"
+    return f"{val:>{width}.{decimals}f}"
+
+
+def _print_grouped_rows(
+    label: str,
+    rows: list[dict[str, Any]],
+    specs: list[tuple[str, int, int]],
+    keys: list[str],
+    mw: int,
+    sep: str,
+) -> None:
+    """Print one data row across all column groups."""
+    parts = [f"{label:<{mw}}"]
+    for i, row in enumerate(rows):
+        if i:
+            parts.append(sep)
+        for j, (_, dec, w) in enumerate(specs):
+            parts.append(_fmt(row.get(keys[j]), dec, w))
+    print("".join(parts))
+
+
+def _print_tf_formatted(
+    splits_data: list[tuple[str, list[dict[str, Any]]]],
+    title: str,
+) -> None:
+    """Print text-following table with Overview / Timeline single / Timeline multi groups.
+
+    *splits_data* is a list of ``(split_label, category_rows)`` tuples so
+    that content and repetition splits appear as separate row-pairs inside
+    one table.
+    """
+    groups = ["Overview", "Timeline single", "Timeline multi"]
+    specs: list[tuple[str, int, int]] = [
+        ("R@3\u2191", 2, 7),
+        ("FID\u2193", 3, 7),
+        ("Skate\u2193", 3, 9),
+        ("Contact\u2191", 3, 10),
+    ]
+    gt_keys = ["R@3 (GT)", None, "Skate (GT, cm/s)", "Contact (GT)"]
+    gen_keys = ["R@3 (gen)", "FID gen-GT", "Skate (gen, cm/s)", "Contact (gen)"]
+    gt_defaults: list[float | None] = [None, 0.0, None, None]
+
+    mw = 16
+    gw = sum(s[2] for s in specs)
+    sep = " | "
+    total_w = mw + len(groups) * gw + (len(groups) - 1) * len(sep)
+
+    print(f"\n{title:^{total_w}}")
+    print("=" * total_w)
+
+    parts: list[str] = [" " * mw]
+    for i, g in enumerate(groups):
+        if i:
+            parts.append(sep)
+        parts.append(g.center(gw))
+    print("".join(parts))
+
+    parts = [f"{'':<{mw}}"]
+    for i in range(len(groups)):
+        if i:
+            parts.append(sep)
+        for hdr, _, w in specs:
+            parts.append(f"{hdr:>{w}}")
+    print("".join(parts))
+
+    parts = ["\u2500" * mw]
+    for i in range(len(groups)):
+        if i:
+            parts.append("\u2500\u253c\u2500")
+        parts.append("\u2500" * gw)
+    print("".join(parts))
+
+    for si, (split_label, rows) in enumerate(splits_data):
+        tag = f"\u2500\u2500 {split_label} "
+        print(tag + "\u2500" * (total_w - len(tag)))
+
+        parts = [f"{'Ground Truth':<{mw}}"]
+        for i, row in enumerate(rows):
+            if i:
+                parts.append(sep)
+            for j, (_, dec, w) in enumerate(specs):
+                key = gt_keys[j]
+                val = gt_defaults[j] if key is None else row.get(key)
+                parts.append(_fmt(val, dec, w))
+        print("".join(parts))
+
+        _print_grouped_rows("Method", rows, specs, gen_keys, mw, sep)
+
+    print()
+
+
+def _print_c_formatted(
+    splits_data: list[tuple[str, list[dict[str, Any]]]],
+    title: str,
+) -> None:
+    """Print constraints table with With text / Without text groups.
+
+    *splits_data* is a list of ``(split_label, category_rows)`` tuples.
+    """
+    groups = ["With text", "Without text"]
+    specs: list[tuple[str, int, int]] = [
+        ("FB Pos\u2193", 3, 10),
+        ("EE Pos\u2193", 3, 10),
+        ("EE Rot\u2193", 3, 10),
+        ("2D Root\u2193", 3, 11),
+        ("Pelvis@95%", 2, 12),
+    ]
+    gt_keys = [
+        "Full-Body Pos (GT, cm)",
+        "End-Effector Pos (GT, cm)",
+        "End-Effector Rot (deg)",
+        "2D Root Pos (GT, cm)",
+        "2D Pelvis Pos@95% (GT, cm)",
+    ]
+    gen_keys = [
+        "Full-Body Pos (gen, cm)",
+        "End-Effector Pos (gen, cm)",
+        "End-Effector Rot (deg)",
+        "2D Root Pos (gen, cm)",
+        "2D Pelvis Pos@95% (gen, cm)",
+    ]
+
+    mw = 16
+    gw = sum(s[2] for s in specs)
+    sep = " | "
+    total_w = mw + len(groups) * gw + (len(groups) - 1) * len(sep)
+
+    print(f"\n{title:^{total_w}}")
+    print("=" * total_w)
+
+    parts: list[str] = [" " * mw]
+    for i, g in enumerate(groups):
+        if i:
+            parts.append(sep)
+        parts.append(g.center(gw))
+    print("".join(parts))
+
+    parts = [f"{'':<{mw}}"]
+    for i in range(len(groups)):
+        if i:
+            parts.append(sep)
+        for hdr, _, w in specs:
+            parts.append(f"{hdr:>{w}}")
+    print("".join(parts))
+
+    parts = ["\u2500" * mw]
+    for i in range(len(groups)):
+        if i:
+            parts.append("\u2500\u253c\u2500")
+        parts.append("\u2500" * gw)
+    print("".join(parts))
+
+    for si, (split_label, rows) in enumerate(splits_data):
+        tag = f"\u2500\u2500 {split_label} "
+        print(tag + "\u2500" * (total_w - len(tag)))
+
+        _print_grouped_rows("Ground Truth", rows, specs, gt_keys, mw, sep)
+        _print_grouped_rows("Method", rows, specs, gen_keys, mw, sep)
+
+    print()
+
+
+def _print_formatted_gt_method(
+    tables: dict[str, dict[str, list[dict[str, Any]]]],
+) -> None:
+    """Print combined tables with column groups separated by vertical bars.
+
+    Content and repetition splits are shown as separate row-pairs inside one text-following table
+    and one constraints table.
+    """
+    tf_splits: list[tuple[str, list[dict[str, Any]]]] = []
+    c_splits: list[tuple[str, list[dict[str, Any]]]] = []
+    for split in SPLITS:
+        split_tables = tables.get(split, {})
+        tf_rows = split_tables.get("text_following", [])
+        c_rows = split_tables.get("constraints", [])
+        if tf_rows and len(tf_rows) == 3:
+            tf_splits.append((split.capitalize(), tf_rows))
+        if c_rows and len(c_rows) == 2:
+            c_splits.append((split.capitalize(), c_rows))
+
+    if tf_splits:
+        _print_tf_formatted(tf_splits, "Text-Following Evaluation")
+    if c_splits:
+        _print_c_formatted(c_splits, "Constrained Evaluation")
+
+
+def _build_summary(root: Path) -> dict[str, Any]:
+    testcase_dirs = _discover_testcase_dirs(root)
+    if not testcase_dirs:
+        raise SystemExit(
+            f"No testcase folders found under {root} (expected folders containing meta.json + motion.npz + gt_motion.npz samples)."
+        )
+
+    missing_results: list[Path] = []
+    for testcase_dir in testcase_dirs:
+        result_path = _expected_result_path(testcase_dir)
+        if not result_path.is_file():
+            missing_results.append(result_path)
+
+    if missing_results:
+        missing_text = "\n".join(str(path) for path in missing_results)
+        raise SystemExit(f"Missing {len(missing_results)} testcase result JSON files:\n{missing_text}")
+
+    row_acc: dict[tuple[str, str], dict[str, Any]] = {}
+    for split in SPLITS:
+        for category in ROW_CATEGORIES:
+            row_acc[(split, category)] = {
+                "num_testcases": 0,
+                "num_motions": 0.0,
+                "per_motion_mean_weighted_sum": {},
+                "per_motion_mean_gt_weighted_sum": {},
+                "tmr_weighted_sum": {},
+                "tmr_weight": 0.0,
+            }
+
+    for testcase_dir in testcase_dirs:
+        split, category = _parse_testcase_key(root, testcase_dir)
+        result_path = _expected_result_path(testcase_dir)
+        num_motions, per_motion_mean_gen, per_motion_mean_gt, tmr = _load_result_row(result_path)
+
+        acc = row_acc[(split, category)]
+        acc["num_testcases"] += 1
+        acc["num_motions"] += num_motions
+        _accumulate_weighted(acc["per_motion_mean_weighted_sum"], per_motion_mean_gen, num_motions)
+        if per_motion_mean_gt:
+            _accumulate_weighted(acc["per_motion_mean_gt_weighted_sum"], per_motion_mean_gt, num_motions)
+        if tmr:
+            _accumulate_weighted(acc["tmr_weighted_sum"], tmr, num_motions)
+            acc["tmr_weight"] += num_motions
+
+    rows: list[dict[str, Any]] = []
+    for split in SPLITS:
+        for category in ROW_CATEGORIES:
+            acc = row_acc[(split, category)]
+            tmr_avg = _to_averages(acc["tmr_weighted_sum"], acc["tmr_weight"]) if acc["tmr_weight"] > 0 else {}
+            per_motion_gt_avg = _to_averages(acc["per_motion_mean_gt_weighted_sum"], acc["num_motions"])
+            row_dict: dict[str, Any] = {
+                "split": split,
+                "category": category,
+                "num_testcases": acc["num_testcases"],
+                "num_motions": int(acc["num_motions"]),
+                "per_motion_mean": _to_averages(acc["per_motion_mean_weighted_sum"], acc["num_motions"]),
+                "tmr": tmr_avg,
+            }
+            if per_motion_gt_avg:
+                row_dict["per_motion_mean_gt"] = per_motion_gt_avg
+            rows.append(row_dict)
+
+        # Combined constraints row for this split.
+        withtext = row_acc[(split, "constraints_withtext")]
+        notext = row_acc[(split, "constraints_notext")]
+        combined_weight = withtext["num_motions"] + notext["num_motions"]
+
+        combined_per_motion = defaultdict(float)
+        combined_per_motion_gt = defaultdict(float)
+        combined_tmr = defaultdict(float)
+        combined_tmr_weight = withtext["tmr_weight"] + notext["tmr_weight"]
+        for source in (
+            withtext["per_motion_mean_weighted_sum"],
+            notext["per_motion_mean_weighted_sum"],
+        ):
+            for k, v in source.items():
+                combined_per_motion[k] += v
+        for source in (
+            withtext["per_motion_mean_gt_weighted_sum"],
+            notext["per_motion_mean_gt_weighted_sum"],
+        ):
+            for k, v in source.items():
+                combined_per_motion_gt[k] += v
+        for source in (withtext["tmr_weighted_sum"], notext["tmr_weighted_sum"]):
+            for k, v in source.items():
+                combined_tmr[k] += v
+
+        combined_tmr_avg = _to_averages(dict(combined_tmr), combined_tmr_weight) if combined_tmr_weight > 0 else {}
+        combined_gt_avg = _to_averages(dict(combined_per_motion_gt), combined_weight)
+        combined_row: dict[str, Any] = {
+            "split": split,
+            "category": "constraints",
+            "num_testcases": withtext["num_testcases"] + notext["num_testcases"],
+            "num_motions": int(combined_weight),
+            "per_motion_mean": _to_averages(dict(combined_per_motion), combined_weight),
+            "tmr": combined_tmr_avg,
+        }
+        if combined_gt_avg:
+            combined_row["per_motion_mean_gt"] = combined_gt_avg
+        rows.append(combined_row)
+
+    tables = _build_tables(row_acc)
+    return {
+        "folder": str(root),
+        "num_testcases": len(testcase_dirs),
+        "rows": rows,
+        "tables": tables,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=("Validate testcase XXX.json result files and aggregate averages by split/category.")
+    )
+    parser.add_argument(
+        "folder",
+        type=Path,
+        help="Testsuite root folder (contains content/ and repetition/).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Optional output JSON path. Default: <folder>/summary_rows.json",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["terminal", "md"],
+        default="terminal",
+        dest="table_format",
+        help="Table output format: 'terminal' (default) for fixed-width tables, 'md' for markdown.",
+    )
+    args = parser.parse_args()
+
+    folder = args.folder.resolve()
+    if not folder.is_dir():
+        raise SystemExit(f"Folder does not exist: {folder}")
+
+    summary = _build_summary(folder)
+
+    out_path = args.output.resolve() if args.output else folder / "summary_rows.json"
+    out_path.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+    print(f"Wrote aggregated summary: {out_path}")
+    print(f"Rows: {len(summary['rows'])}, testcases: {summary['num_testcases']}")
+    if args.table_format == "md":
+        _print_formatted_gt_method_md(summary["tables"])
+    else:
+        _print_formatted_gt_method(summary["tables"])
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/source/benchmark/introduction.md
+++ b/docs/source/benchmark/introduction.md
@@ -1,0 +1,141 @@
+# Benchmark Introduction
+
+We provide a benchmark to evaluate text-to-motion and constrained motion generation on a shared test suite.
+For reproducibility, all test content is stored on disk as folders and files, so anyone can run exactly the same cases.
+The benchmark test suite is available to download from HuggingFace at [`nvidia/Kimodo-Motion-Gen-Benchmark`](https://huggingface.co/datasets/nvidia/Kimodo-Motion-Gen-Benchmark) and is currently set up for use with models trained on the [SOMA](https://github.com/NVlabs/SOMA-X) body skeleton.
+
+The benchmark contains text prompts, durations, and constraint configurations for a variety of test cases, but **not** the ground-truth motion data itself. The ground-truth motions are derived from the [BONES-SEED dataset](https://huggingface.co/datasets/bones-studio/seed), which has its own license you should consider. So to construct the full benchmark motions, you must download the BONES-SEED dataset separately and run our `create_benchmark` script to populate the test suite with ground-truth motions. 
+
+Constructing the benchmark with `create_benchmark` is the first step in the full [Evaluation Pipeline](pipeline.md), which is described in detail on the next page. In addition to the benchmark test cases, we provide code to run generation with Kimodo and compute a variety of [metrics](metrics.md) measuring motion quality, text alignment, and constraint following. While this open-sourced public test suite is not the exact same used in the [Kimodo tech report](https://research.nvidia.com/labs/sil/projects/kimodo/assets/kimodo_tech_report.pdf) (Sec. 6.1), the evaluation metrics are the same and evaluation methodology is similar.
+
+On this page, we describe the overall structure of the test suite and details of the different test cases. Then in subsequent pages, we describe how to run the full [evaluation pipeline](pipeline.md), detail the [metrics](metrics.md), and finally provide the [results](results.md) of Kimodo-SOMA-RP and Kimodo-SOMA-SEED on the benchmark.
+
+## Dataset Splits
+To evaluate a model on the benchmark, it should be trained with the [provided splits](https://huggingface.co/datasets/nvidia/Kimodo-Motion-Gen-Benchmark/tree/main/splits) for the [BONES-SEED dataset](https://huggingface.co/datasets/bones-studio/seed).
+
+The different splits are defined in:
+
+- `train_split_paths.txt` - filenames of training data
+- `test_content_split_paths.txt` - filenames for test split containing new semantic "content". This split contains motions with `content_name` (from the BONES-SEED metadata) that are not seen in the training split. This tests model generalization to new semantic motion types, e.g. for text-to-motion generalization.
+- `test_repetition_split_paths.txt` - filenames for test split containing new motions from content that was seen in training. This split contains motions where the `content_name` is contained in the training split, but the exact motion itself was not seen. This tests a model's ability to generalize to novel performances of a familiar motion type, e.g., for constraint-following generalization.
+
+The training split should be used for training, while the two test splits (`content` and `repetition`) are used in the test suite, as described below. Note that the test cases in the benchmark do not cover the entire content and repetition test splits, instead we strategically sample a subset that maximizes content diversity.
+
+## Test Suite Structure
+
+The full test suite contains 22,474 test cases spanning text and constraint-conditioned motion generation. 
+The suite is organized hierarchically to logically group together test cases, so the evaluation pipeline can be run on a subset of the benchmark instead of the full thing, if desired.
+
+After the benchmark has been constructed and motions generated for the model to evaluate, a **test case** is a single folder containing:
+
+- `meta.json` (**required**): text prompt(s) and duration(s),
+- `constraints.json` (**optional**): constraints for controlled generation, using the [constraints format](../user_guide/constraints.md),
+- `gt_motion.npz` (**optional**): ground-truth/reference motion, using the [NPZ output format](../user_guide/output_formats.md),
+- `motion.npz` (**optional**): output of the model given the `meta.json` prompt/duration and optional `constraints.json`, using the same [NPZ output format](../user_guide/output_formats.md).
+
+In addition to being used in the evaluation pipeline, each test case can be:
+
+- loaded in the interactive demo through **Load Example** for visualization,
+- loaded in `kimodo_gen` with `--input_folder` for generation from folder-defined inputs.
+
+### Benchmark Folder Hierarchy
+
+The full suite is organized as follows:
+
+```text
+testsuite
+├── content
+│   ├── constraints_notext
+│   │   ├── end-effectors
+│   │   ├── fullbody
+│   │   ├── mixture
+│   │   └── root
+│   ├── constraints_withtext
+│   │   ├── end-effectors
+│   │   ├── fullbody
+│   │   ├── mixture
+│   │   └── root
+│   └── text2motion
+│       ├── overview
+│       ├── timeline_multi
+│       └── timeline_single
+└── repetition
+    ├── constraints_notext
+    │   ├── end-effectors
+    │   ├── fullbody
+    │   ├── mixture
+    │   └── root
+    ├── constraints_withtext
+    │   ├── end-effectors
+    │   ├── fullbody
+    │   ├── mixture
+    │   └── root
+    └── text2motion
+        ├── overview
+        ├── timeline_multi
+        └── timeline_single
+```
+
+At the highest level, the test suite is organized by the test split used. As discussed previously, `content` refers to the test split with held out semantic categories of motion, while `repetition` refers to held out motions from semantic categories seen during training. 
+
+Within each test split, test cases are organized into:
+
+* `text2motion`: test cases with only text prompts as input (no constraints)
+* `constraints_notext`:  test cases with only constraints as input (no text prompt)
+* `constraints_withtext`: test cases with both prompt and constraints as input
+
+### Text2Motion Test Cases
+
+These test cases are pure text-to-motion with no constraints as input. `text2motion` test cases exclusively use prompts derived from our [SEED timeline annotations](https://huggingface.co/datasets/nvidia/SEED-Timeline-Annotations). It contains three types of test cases:
+
+* `overview`: medium-detail prompt that describes a full motion. Corresponds to `overview_description` in the [NVIDIA SEED timelines](https://huggingface.co/datasets/nvidia/SEED-Timeline-Annotations) or equivalently `content_natural_desc_4` in the [BONES SEED](https://huggingface.co/datasets/bones-studio/seed) metadata.
+* `timeline_single`: fine-grained prompt describing a single segment of a timeline annotation. Corresponds to a single event in a SEED timeline.
+* `timeline_multi`: fine-grained prompt describing multiple subsequent segments of a timeline annotation. Corresponds to multiple contiguous events in a SEED timeline, which have been concatenated with an LLM to get a single natural text description.
+
+### Constrained Test Cases
+
+Constrained test cases provide a constraint input either without a text prompt (i.e., `constraints_notext`) or with an `overview` text prompt (i.e., `constraints_withtext`). The different types of constraint categories mirror the [constraint types support by Kimodo](../key_concepts/constraints.md) and include:
+
+* `fullbody`: constrains all joint positions in the skeleton at specific frames
+* `end-effectors`: constraints the position and rotations of hand and/or feet joints at specific frames
+* `root`: constraints the 2D root position and optionally heading on a path or at specific frames
+* `mixture`: evaluates compositional control when multiple constraint families are combined
+
+Within each constraint type in the hierarchy are multiple subtypes that vary the constraint sparsity patterns (either in time or in space). So the hierarchy of a `constraint` folder is:
+
+```text
+constraints_XX
+├── end-effectors
+│   ├── feet_posrot          # feet only constraints
+│   ├── hands_feet_posrot    # hands + feet constraints
+│   └── hands_posrot         # hands only constraints
+├── fullbody
+│   ├── inbetweening         # constraints at start and end only
+│   └── random               # constraints at random frames
+├── mixture
+│   ├── root_ee_hands_feet_posrot_fullbody    # mix of (1) root trajectory, (2) hand + foot, and (3) full-body 
+│   ├── root_ee_hands_posrot                  # mix of (1) root keyframe, and (2) hands
+│   ├── root_ee_hands_posrot_fullbody         # mix of (1) root keyframe, (2) hands, and (3) full-body
+│   └── root_path_fullbody                    # mix of (1) root trajectory, and (2) full-body
+└── root
+    ├── path_2dpos             # root trajectory position
+    ├── path_2dposrot          # root trajecotry position + heading
+    ├── waypoint_2dpos         # root waypoint position
+    └── waypoint_2dposrot      # root waypoint position + heading
+```
+
+### Indexed Test Cases in Leaf Folders
+
+Each leaf folder contains indexed test cases (`0000`, `0001`, `0002`, ...).
+For example:
+
+```text
+end-effectors/feet_posrot/
+├── 0000/
+├── 0001/
+├── 0002/
+...
+└── 0255/
+```
+
+Each index folder is one standalone test case with its own `meta.json`, optional `constraints.json`, optional `gt_motion.npz`, and optional `motion.npz`.

--- a/docs/source/benchmark/metrics.md
+++ b/docs/source/benchmark/metrics.md
@@ -1,0 +1,259 @@
+# Metrics
+
+The benchmark evaluates generated motion along three axes:
+
+- **Motion quality** -- foot-skate and contact-consistency metrics,
+- **Constraint following** -- position error for root, end-effector, and full-body constraints,
+- **Text alignment** -- TMR retrieval and distributional metrics.
+
+Metrics are implemented in `kimodo/metrics/` and orchestrated by `benchmark/evaluate_folder.py`.
+The protocol is aligned with the [tech report](https://research.nvidia.com/labs/sil/projects/kimodo/assets/kimodo_tech_report.pdf) (Sec. 6.1, "Evaluation Metrics").
+
+## Evaluation Protocol
+
+The evaluation pipeline runs two passes over each group of test cases:
+
+1. **Generated pass** -- evaluates `motion.npz` with all metrics (foot skate, contact consistency, constraint following) and, when TMR embeddings are available, computes retrieval and FID scores.
+2. **Ground-truth pass** -- evaluates `gt_motion.npz` with the same motion-quality and constraint metrics. TMR retrieval metrics are not recomputed in this pass.
+
+Running both passes enables side-by-side comparison: the GT row serves as an empirical upper bound for motion quality, and deviations between GT and generated metrics highlight where the model can improve. See [Evaluation pipeline](pipeline.md) for the full workflow.
+
+## Metrics Reference
+
+The table below lists every key written to `metrics.json`. Detailed descriptions follow in subsequent sections.
+
+| Key | Category | Unit | Direction |
+| --- | --- | --- | --- |
+| `foot_skate_from_height` | Motion quality | m/s | Lower is better |
+| `foot_skate_from_pred_contacts` | Motion quality | m/s | Lower is better |
+| `foot_skate_max_vel` | Motion quality | m/s | Lower is better |
+| `foot_skate_ratio` | Motion quality | ratio (0--1) | Lower is better |
+| `foot_contact_consistency` | Motion quality | ratio (0--1) | Higher is better |
+| `constraint_root2d_err` | Constraint follow | m | Lower is better |
+| `constraint_root2d_err_p95` | Constraint follow | m | Lower is better |
+| `constraint_root2d_acc` | Constraint follow | ratio (0--1) | Higher is better |
+| `constraint_fullbody_keyframe` | Constraint follow | m | Lower is better |
+| `constraint_end_effector` | Constraint follow | m | Lower is better |
+| `TMR/t2m_sim` | Text alignment | score (0--1) | Higher is better |
+| `TMR/t2m_R/R01` ... `R10` | Text alignment | % | Higher is better |
+| `TMR/t2m_R/MedR` | Text alignment | rank | Lower is better |
+| `TMR/FID/gen_text` | Text alignment | distance | Lower is better |
+| `TMR/FID/gen_gt` | Text alignment | distance | Lower is better |
+| `TMR/FID/gt_text` | Text alignment | distance | Lower is better |
+| `TMR/m2m_sim` | Text alignment | score (0--1) | Higher is better |
+| `TMR/t2m_gt_sim` | Text alignment | score (0--1) | Higher is better |
+| `TMR/m2m_R/R01` ... `R10` | Text alignment | % | Higher is better |
+| `TMR/t2m_gt_R/R01` ... `R10` | Text alignment | % | Higher is better |
+
+:::{note}
+Raw metric values are stored in SI units (meters for positions, m/s for velocities).
+The summary tables printed by `benchmark/parse_folder.py` convert constraint position errors to **cm** and foot-skate velocities to **cm/s** for readability.
+:::
+
+### Foot Skating Metrics
+
+Foot skating measures how much a foot slides along the ground when it should be in static contact with the ground. Four complementary metrics capture different aspects of this artifact.
+
+- **`foot_skate_from_height`** (m/s, lower is better):
+  Mean velocity of the **toe joints** (left toe, right toe) on frames where the toe height is below a floor threshold (`height_thresh = 0.05 m`).
+  This metric does not rely on predicted contact labels -- it uses a geometric criterion (Y-coordinate < threshold) to identify ground-contact frames.
+
+- **`foot_skate_from_pred_contacts`** (m/s, lower is better):
+  Mean velocity of all **four foot joints** (left/right heel and toe) on frames where the model predicts contact via the `foot_contacts` output.
+  Unlike `foot_skate_from_height`, this metric trusts the model's own contact predictions and measures all four foot joints rather than toes only.
+
+- **`foot_skate_max_vel`** (m/s, lower is better):
+  Maximum velocity across all four foot joints and all time steps where predicted contact is active.
+  This captures worst-case slip spikes that mean-based metrics can hide.
+
+- **`foot_skate_ratio`** (ratio 0--1, lower is better):
+  Fraction of ground-contact frames where toe velocity exceeds a threshold (`vel_thresh = 0.2 m/s`). A frame counts as ground contact when the toe is below `height_thresh = 0.05 m` on both the current and the next frame. Inspired by the [GMD](https://github.com/korrawe/guided-motion-diffusion) skating metric.
+
+### Contact Consistency Metric
+
+- **`foot_contact_consistency`** (ratio 0--1, higher is better):
+  Agreement between the model's predicted foot contacts and a heuristic contact detector based on joint height and velocity (`vel_thresh = 0.15 m/s`, `height_thresh = 0.10 m`).
+  Computed as accuracy (`1 - incorrect_ratio`) over all time steps and four contact channels.
+  A score of 1.0 means perfect agreement between predicted and heuristic contacts.
+  As noted in the [tech report](https://research.nvidia.com/labs/sil/projects/kimodo/assets/kimodo_tech_report.pdf), this metric provides important context for interpreting the contact-based foot-skate metrics above: if contact consistency is low, `foot_skate_from_pred_contacts` may be unreliable.
+
+### Constraint-Following Metrics
+
+Constraint metrics are computed only when the test case includes a `constraints.json` file. The `ContraintFollow` metric class dispatches by [constraint type](../key_concepts/constraints.md):
+
+- **`constraint_end_effector`** (m, lower is better):
+  Mean Euclidean distance between target end-effector positions and generated joint positions at the constrained frames.
+  Only position-constrained joints are evaluated (rotation targets are not measured by this metric).
+
+- **`constraint_fullbody_keyframe`** (m, lower is better):
+  Mean per-joint Euclidean distance between target and generated full-body joint positions at keyframes.
+  The error is averaged over all joints and all keyframe frames.
+
+- **`constraint_root2d_err`** (m, lower is better):
+  Mean 2D Euclidean distance (in the XZ ground plane) between target and generated root positions at constrained frames.
+
+- **`constraint_root2d_err_p95`** (m, lower is better):
+  95th percentile of the per-frame root 2D error across all samples in a group.
+  Computed during aggregation by `evaluate_folder.py` to capture tail-end failures that the mean can mask.
+
+- **`constraint_root2d_acc`** (ratio 0--1, higher is better):
+  Fraction of constrained root frames where the 2D position error is within a distance threshold (`root_threshold = 0.10 m`).
+
+### TMR-Based Metrics
+
+Text alignment is evaluated using [TMR](https://mathis.petrovich.fr/tmr/) (Text-to-Motion Retrieval), a separate encoder model that maps both text and motion into a shared embedding space. TMR is not used for generation -- it is loaded only for evaluation (see `kimodo/model/tmr.py`).
+
+We release a version of TMR retrained on the full Rigplay dataset as [`TMR-SOMA-RP-v1`](https://huggingface.co/nvidia/TMR-SOMA-RP-v1). The original TMR was trained on HumanML3D; our retrained variant uses the same architecture but is trained on the Rigplay motion dataset, SOMA skeleton, and with [LLM2Vec](https://github.com/McGill-NLP/llm2vec) text embeddings.
+
+#### Similarity Scores
+
+TMR encodes each text prompt and each motion clip into a unit-length embedding vector. Cosine similarity between text and motion embeddings is rescaled to a [0, 1] range:
+
+```
+score = cosine_similarity / 2 + 0.5
+```
+
+Three per-test-case similarity scores are recorded:
+
+- **`TMR/t2m_sim`** (0--1, higher is better): similarity between the text prompt and the generated motion.
+- **`TMR/m2m_sim`** (0--1, higher is better): similarity between the generated and ground-truth motions (only when GT is available).
+- **`TMR/t2m_gt_sim`** (0--1, higher is better): similarity between the text prompt and the GT motion (only when GT is available).
+
+#### R-precision (Retrieval Accuracy)
+
+R-precision measures whether the correct motion can be retrieved from a pool given its corresponding text query.
+For each text query in the evaluation group, all motions are ranked by TMR similarity.
+R@k is the percentage of queries where the correct motion appears in the top k results.
+
+Reported keys: `TMR/t2m_R/R01`, `R02`, `R03`, `R05`, `R10` (%), and `TMR/t2m_R/MedR` (median rank, lower is better) correspond to retrieval accuracy when using generated motions.
+
+When ground-truth motions are available, analogous retrieval metrics are computed for motion-to-GT-motion (`TMR/m2m_R/...`) and text-to-GT-motion (`TMR/t2m_gt_R/...`).
+
+:::{note}
+Near-duplicate text prompts can artificially penalize retrieval ranking. The evaluation handles this by grouping prompts whose text-text similarity exceeds a threshold of 0.99 and treating any motion in that group as a valid match.
+:::
+
+#### FID (Frechet Inception Distance)
+
+FID measures distributional distance between two sets of TMR embeddings by fitting a multivariate Gaussian to each set and computing the Frechet distance. Three FID variants are reported:
+
+- **`TMR/FID/gen_gt`**: distance between generated-motion and GT-motion embeddings (only when GT is available). This is the FID metric that is typically reported in the motion generation literature.
+- **`TMR/FID/gen_text`**: distance between generated-motion embeddings and text embeddings. 
+- **`TMR/FID/gt_text`**: distance between GT-motion and text embeddings (only when GT is available).
+
+Lower values indicate that the two distributions are more similar. FID requires at least 2 samples; groups with fewer samples report `NaN`.
+
+#### Per-Test-Case Retrieval
+
+In addition to the aggregate metrics above, each test case's `metrics.json` includes a `tmr` block with single motion retrieval results:
+
+- `t2m_rank`: the rank of the correct motion when retrieving with this test case's text query.
+- `top5_retrieved`: the top-5 retrieved motions (sample IDs and text prompts) for inspection.
+
+## JSON Output Format
+
+Below is a representative `metrics.json` written by `evaluate_folder.py` for a single test case with mixed constraints (root + end-effector + full-body) and TMR embeddings:
+
+```json
+{
+  "num_motions": 1,
+  "folder": "...",
+  "per_motion_mean_gen": {
+    "foot_skate_from_height": 0.3144,
+    "foot_skate_from_pred_contacts": 0.0672,
+    "foot_skate_max_vel": 0.2109,
+    "foot_contact_consistency": 0.9522,
+    "foot_skate_ratio": 0.2182,
+    "constraint_end_effector": 0.0286,
+    "constraint_root2d_err": 0.0534,
+    "constraint_root2d_acc": 1.0,
+    "constraint_fullbody_keyframe": 0.0324,
+    "TMR/t2m_sim": 0.8209
+  },
+  "per_motion_mean_gt": {
+    "foot_skate_from_height": 0.2361,
+    "foot_skate_from_pred_contacts": 0.0269,
+    "foot_skate_max_vel": 0.1459,
+    "foot_contact_consistency": 1.0,
+    "foot_skate_ratio": 0.1402,
+    "constraint_end_effector": 9.82e-07,
+    "constraint_root2d_err": 0.0407,
+    "constraint_root2d_acc": 1.0,
+    "constraint_fullbody_keyframe": 8.73e-07
+  },
+  "tmr": {
+    "t2m_rank": 2,
+    "text": "A person is swiftly performing a dance move by moving their hands and legs.",
+    "top5_retrieved": [
+      {
+        "id": "0231",
+        "text": "A person is performing dance steps while stepping back and forward..."
+      },
+      {
+        "id": "0029",
+        "text": "A person is swiftly performing a dance move by moving their hands and legs."
+      }
+    ]
+  }
+}
+```
+
+Group-level aggregate JSONs (`<group_name>.json`) have the same structure but with `num_motions > 1`, averaged per-motion metrics, additional keys like `constraint_root2d_err_p95`, and a `tmr` block containing the aggregate retrieval and FID scores:
+
+```json
+{
+  "num_motions": 256,
+  "folder": "...",
+  "per_motion_mean_gen": {
+    "foot_skate_from_height": 0.1742,
+    "foot_skate_from_pred_contacts": 0.0611,
+    "foot_skate_max_vel": 0.3747,
+    "foot_contact_consistency": 0.9483,
+    "foot_skate_ratio": 0.1499,
+    "constraint_end_effector": 0.0367,
+    "constraint_root2d_err": 0.0495,
+    "constraint_root2d_acc": 0.9212,
+    "constraint_fullbody_keyframe": 0.0324,
+    "constraint_root2d_err_p95": 0.1115
+  },
+  "per_motion_mean_gt": {
+    "foot_skate_from_height": 0.1617,
+    "foot_skate_from_pred_contacts": 0.0235,
+    "foot_skate_max_vel": 0.1185,
+    "foot_contact_consistency": 1.0,
+    "foot_skate_ratio": 0.1214,
+    "constraint_end_effector": 1.48e-06,
+    "constraint_root2d_err": 0.0376,
+    "constraint_root2d_acc": 1.0,
+    "constraint_fullbody_keyframe": 1.16e-06,
+    "constraint_root2d_err_p95": 0.0602
+  },
+  "tmr": {
+    "TMR/t2m_sim": 0.8742,
+    "TMR/t2m_R/R01": 75.39,
+    "TMR/t2m_R/R02": 85.55,
+    "TMR/t2m_R/R03": 88.28,
+    "TMR/t2m_R/R05": 90.23,
+    "TMR/t2m_R/R10": 93.36,
+    "TMR/t2m_R/MedR": 1.0,
+    "TMR/t2m_R/len": 256.0,
+    "TMR/FID/gen_text": 0.1442,
+    "TMR/m2m_R/R01": 94.53,
+    "TMR/m2m_R/R02": 97.66,
+    "TMR/m2m_R/R03": 98.05,
+    "TMR/m2m_R/R05": 98.83,
+    "TMR/m2m_R/R10": 99.22,
+    "TMR/m2m_R/MedR": 1.0,
+    "TMR/m2m_R/len": 256.0,
+    "TMR/t2m_gt_R/R01": 80.47,
+    "TMR/t2m_gt_R/R02": 88.28,
+    "TMR/t2m_gt_R/R03": 91.02,
+    "TMR/t2m_gt_R/R05": 92.58,
+    "TMR/t2m_gt_R/R10": 94.53,
+    "TMR/t2m_gt_R/MedR": 1.0,
+    "TMR/t2m_gt_R/len": 256.0,
+    "TMR/FID/gen_gt": 0.0387,
+    "TMR/FID/gt_text": 0.1349
+  }
+}
+```

--- a/docs/source/benchmark/pipeline.md
+++ b/docs/source/benchmark/pipeline.md
@@ -1,0 +1,184 @@
+# Evaluation Pipeline
+
+This page describes the full benchmark workflow, which uses scripts in the `benchmark` directory:
+
+1. Build full test suite using ground-truth motions from BONES-SEED BVH data and benchmark metadata (`create_benchmark.py`),
+2. Generate motions with a model for all or part of the test suite (`generate_eval.py`),
+3. Compute text/motion embeddings with pre-trained TMR model (`embed_folder.py `),
+4. Evaluate metrics over all generated samples (`evaluate_folder.py`),
+5. Aggregate and summarize results (`parse_folder.py`).
+
+This pipeline works off-the-shelf for Kimodo models. To evaluate your own model, step (2) will need to be modified to generate with your custom model and output in the expected npz format.
+
+## Prerequisite: Download Motion Data and Metadata
+The benchmark is constructed from motions in the BONES-SEED dataset and our released metadata. Make sure you have downloaded the [BONES-SEED dataset](https://huggingface.co/datasets/bones-studio/seed) along with the metadata for the test suite from HuggingFace at [`nvidia/Kimodo-Motion-Gen-Benchmark`](https://huggingface.co/datasets/nvidia/Kimodo-Motion-Gen-Benchmark). 
+
+The `testsuite` folder from the downloaded metadata contains the directory structure described in the [benchmark introduction](introduction.md) with `meta.json`, `seed_motion.json`, and `seed_constraints.json` metadata files in the leaf folders. These metadata files contain info about the text prompts, durations, and constraint definitions for each test case. The first two steps of the evaluation pipeline will create the following in the leaf folders to prepare for computing metrics:
+
+- **Ground-Truth Motion** (`gt_motion.npz`): produced by `create_benchmark.py` from SEED BVH + metadata.
+- **Constraints Configuration** (`constraints.json`): for test caases with constraint inputs, this file is created by `create_benchmark.py` from SEED BVH + metadata.
+- **Generated Motion** (`motion.npz`): produced by the generation step from the model to evaluate (e.g. `generate_eval.py`).
+
+To perform the full evaluation, including metrics for both ground-truth and generated motions (steps 3--5), each leaf folder must contain both `gt_motion.npz` and `motion.npz`.
+
+> Note: all of the following steps will work with a _subset_ of the full test suite, if desired. Anywhere the `testsuite` directory is passed in, it can be replaced with a specific subset such as `testsuite/content/text2motion` to only run this subset of the benchmark.
+
+## 1. Build Full Benchmark (`create_benchmark.py`)
+
+ The `create_benchmark.py` script bridges the ground truth motions and metadata: it downloads the testsuite structure (if not already present locally), then reads the referenced BVH files from a local copy of BONES-SEED and writes `gt_motion.npz` and `constraints.json` into each sample folder.
+
+```bash
+python benchmark/create_benchmark.py path/to/testsuite --dataset datasets/bones-seed/soma_uniform
+```
+
+By default, this construction can take several hours and the resulting folder is about **26 GB**. 
+
+To run faster, you can increase the number of parallel workers for processing:
+```bash
+OMP_NUM_THREADS=2 python benchmark/create_benchmark.py path/to/testsuite --dataset datasets/bones-seed/soma_uniform --workers 16
+```
+This example runs well with a 32-core system, but you may need to adjust the number of threads-per-worker and total workers for your system. Generally, a lower number of threads-per-worker with larger number of workers (up to your available CPU capacity) runs fastest.
+
+Options:
+
+- `--dataset`: path to the local SEED dataset folder (default: `datasets/bones-seed/soma_uniform`).
+- `--workers`: number of parallel workers to use for benchmark construction (default: 1, sequential)
+- `--overwrite`: rebuild `gt_motion.npz` even if it already exists.
+
+For each test case, the script:
+
+1. parses the BVH file into local rotation matrices and root translation,
+2. subsamples to 30 FPS,
+3. converts to the standard T-pose via `SOMASkeleton77.to_standard_tpose`,
+4. computes Kimodo motion features and canonicalizes the motion,
+5. writes the resulting motion dictionary as `gt_motion.npz`.
+
+For a detailed walkthrough of steps 1--4, see [Loading BONES-SEED BVH data](../user_guide/seed_dataset.md).
+
+## 2. Generate Motions (`generate_eval.py`)
+
+The next step is to generate a motion for each test case.
+The script `benchmark/generate_eval.py` recursively generates one motion with Kimodo per test case from either the full `testsuite` or a  desired subset. 
+
+```bash
+python benchmark/generate_eval.py \
+  --benchmark path/to/testsuite \
+  --output generated_folder \
+  --model kimodo-soma-rp \
+  --batch_size 32 \
+  --num_workers 4
+```
+
+The batch size and number of data workers should be adjusted for your system. The script is intended to be run with the latest Kimodo-SOMA models (right now v1.1) which are compatible with the benchmark.
+
+> Note: each test cases has a seed in `meta.json` that is  loaded and used for generation to enable reproducibility. However, by default, the generation script uses the first seed in a batch to seed the whole batch, so to make results completely repeatable, you must set the batch size to 1 or always use the same batch size when running generation.
+
+Useful options:
+
+- `--model`: Kimodo model to use for generation. See [available models](../getting_started/quick_start.md#overview-kimodo-models) for the full list. 
+- `--output`: output root directory. The testsuite hierarchy is mirrored here. If omitted, motions are generated **in-place** inside the testsuite folder.
+- `--overwrite`: regenerate even if `motion.npz` already exists.
+- `--diffusion_steps`: default denoising steps (can be overridden by each sample `meta.json`).
+- `--postprocess`: enable post-processing. For fair evaluation, it is recommended to **not** use post-processing so that metrics reflect the raw model output.
+- `--text_encoder_fp32`: will instantiate the text encoder (if needed) with float32 precision instead of bfloat16. The Kimodo v1.1 models are trained with float32 text encodings, so this slightly improves accuracy but requires extra VRAM.
+
+After generation, the output tree mirrors the `testsuite` hierarchy and includes generated motions (`motion.npz`). If the testsuite was built with `create_benchmark.py`, each leaf already has `gt_motion.npz`; the generation step adds `motion.npz` per sample.
+
+```text
+generated_folder/
+└── .../0000/
+    ├── meta.json
+    ├── constraints.json                # present if available in testsuite
+    ├── gt_motion.npz                   # if built with create_benchmark
+    └── motion.npz                      # generated
+```
+
+### Using Custom Models
+
+The `generate_eval` script is set up to work with Kimodo models, but it can be easily adapted or replaced by generation with a custom model. The only requirement to be able to compute all metrics is to output the `motion.npz` file for each test case that minimally contains: (1) `posed_joints` field with global joint positions on the SOMA 77-joint skeleton and (2) `foot_contacts` field with binary foot contact predictions. Please see the [output formats docs](../user_guide/output_formats.md) for more details on the `NPZ` format.
+
+## 3. Embed with Pre-Trained TMR (`embed_folder.py`)
+
+Several evaluation metrics such as R-precision, FID, and latent similarity rely on latent embeddings of both motion and text. For this purpose, we use a [Text-Motion-Retrieval (TMR)](https://mathis.petrovich.fr/tmr/) model trained on the full Bones Rigplay dataset. See [Metrics](metrics.md) for details on the TMR evaluation protocol and metrics. 
+
+The next step in the eval pipeline is using this TMR model with the `benchmark/embed_folder.py` script to recursively embed each generated motion (`motion.npz`), GT motion (`gt_motion.npz`) when present, and the text prompt from `meta.json`:
+
+```bash
+python benchmark/embed_folder.py generated_folder --model tmr-soma-rp
+```
+
+The default TMR model (`tmr-soma-rp`) trained on the full Rigplay dataset is released as [`TMR-SOMA-RP-v1`](https://huggingface.co/nvidia/TMR-SOMA-RP-v1). It is automatically downloaded from HuggingFace on first use of the embedding script. 
+
+Options:
+
+- `--model`: TMR model to use for encoding (default: `tmr-soma-rp`).
+- `--device`: compute device (`cuda` or `cpu`). Defaults to `cuda` if available, otherwise `cpu`.
+- `--overwrite`: re-embed even if embedding files already exist.
+- `--text_encoder_fp32`: will instantiate the text encoder (if needed) with float32 precision instead of bfloat16. The TMR model is trained with float32 text encodings, so this slightly improves accuracy but requires extra VRAM.
+
+Running this script saves the embeddings to each test case folder that has the corresponding motion file(s) and `meta.json`:
+
+- `motion_embedding.npy` (when `motion.npz` exists)
+- `gt_motion_embedding.npy` (when `gt_motion.npz` exists)
+- `text_embedding.npy`
+
+> Note: this script can take over 1 hour to run for the full test suite, depending on your GPU.
+
+## 4. Compute Evaluation Metrics (`evaluate_folder.py`)
+
+Next, use `benchmark/evaluate_folder.py` to compute per-test-case and aggregated metrics across the test suite (or a specific subset folder). Each leaf folder must contain both `motion.npz` and `gt_motion.npz` to compute the metrics.
+
+```bash
+python benchmark/evaluate_folder.py generated_folder
+```
+
+Options:
+
+- `--device`: compute device (`cuda` or `cpu`). Defaults to `cuda` if available, otherwise `cpu`.
+
+The script runs two evaluation passes: one on the generated motion (`motion.npz`) and one on the ground-truth motion (`gt_motion.npz`). It outputs:
+
+- per test case results: `metrics.json` inside each test case (leaf) folder with metrics summarized for that single test case
+- per group results: `<group_name>.json` one level above each group of test-case folders that aggregates metrics over all contained test cases
+
+Please see the [Metrics](metrics.md) page for a detailed explanation of these json formats.
+
+After embedding and evaluation, the folder structure should look like:
+
+```text
+generated_folder/
+├── .../0000/
+│   ├── motion.npz
+│   ├── gt_motion.npz
+│   ├── motion_embedding.npy
+│   ├── gt_motion_embedding.npy
+│   ├── text_embedding.npy
+│   └── metrics.json              # single test-case metrics
+└── .../<group_name>.json         # folder-level aggregate summary of all contained test cases
+```
+
+## 5. Summarize Results of Full Benchmark (`parse_folder.py`)
+
+If you have computed metrics for the _entire_ test suite (both `content` and `repetition` splits), use `benchmark/parse_folder.py` to validate all per-test-case result JSONs and aggregate metrics into summary tables. Unlike the previous steps, this script expects the user to pass in the root `testsuite` and for the test suite to follow the standard split/category hierarchy (see [Introduction](introduction.md)):
+
+- **Splits**: `content`, `repetition`
+- **Categories**: `overview`, `timeline_single`, `timeline_multi` (text-following), `constraints_withtext`, `constraints_notext` (constrained generation)
+
+```bash
+python benchmark/parse_folder.py generated_folder
+```
+
+Options:
+
+- `--output`: path for the output JSON (default: `<folder>/summary_rows.json`).
+- `--format`: table output format. `terminal` (default) for fixed-width tables, `md` for markdown tables suitable for copy-pasting into documentation.
+
+The script:
+
+1. discovers all grouped test case directories (folders containing single test cases with `meta.json`, `motion.npz`, and `gt_motion.npz`),
+2. loads each group's `<group_name>.json` result files written by `evaluate_folder`,
+3. computes weighted averages of all metrics by split and category,
+4. writes `summary_rows.json` with per-row and per-table aggregated results,
+5. prints formatted benchmark tables to the terminal (text-following and constraints, with GT and method rows side by side).
+
+Metric values in the tables are converted to user-friendly units (e.g., constraint position errors in cm, foot skating in cm/s). See [Metrics](metrics.md) for definitions of individual metrics.

--- a/docs/source/benchmark/results.md
+++ b/docs/source/benchmark/results.md
@@ -1,0 +1,96 @@
+# Kimodo Results
+
+On this page, we report the results for the latest Kimodo models on the benchmark test suite. These results are reproducible with the [evaluation pipeline](pipeline.md) and should be used when comparing against other models. Note that the reported numbers differ from the numbers in the [tech report](https://research.nvidia.com/labs/sil/projects/kimodo/assets/kimodo_tech_report.pdf) (Sec. 6) due to differences in skeleton, test suite composition, and evaluation details.
+
+To reproduce these results or evaluate your own model, follow the [evaluation pipeline](pipeline.md) and use `parse_folder --format md` to generate summary tables in markdown format.
+
+**Note on reproducibility**: to exactly reproduce the results in the tables below, use batch size 1 when generating with Kimodo (i.e., when running `generate_eval.py`). This way, every test case is individually seeded according to `meta.json`. The reported results were computed using LLM2Vec in the default `bfloat16` precision. However, the Kimodo-SOMA-v1.1 and TMR models were actually trained with `float32` embeddings, so if you want to get the best possible performance (and you have enough VRAM), you can include `--text_encoder_fp32` when running the generation and embedding steps, even though the results will not match the tables here.
+
+Results are reported on the two splits described in [the introduction](introduction.md#dataset-splits):
+
+- **Content**: test cases with novel semantic content not present in training (e.g. unseen action categories).
+- **Repetition**: content categories seen during training, but specific motion clips are held out and unseen. Note that due to the annotations in Bones Rigplay and SEED datasets, the text prompts in this test split have already been seen during training.
+
+For each split, we also report metrics for the ground truth motion. These rows serve as an empirical upper bound for motion quality, and deviations between ground truth and generated metrics highlight where the model can improve.
+
+We split results for each model into two tables corresponding to different test cases in the test suite:
+
+- **Text-Following**: `overview`, `timeline_single`, and `timeline_multi`
+- **Constrained**: `constraints_withtext`, `constraints_notext`
+
+<!-- 
+## Kimodo-SOMA-SEED-v1.1
+These results are for the Kimodo model trained on the public [BONES-SEED](https://huggingface.co/datasets/bones-studio/seed) dataset. The results are comparable to any model trained on SEED that uses our recommended splits [described in the introduction](introduction.md#dataset-splits).
+
+### Text-Following Evaluation
+
+|  | Overview R@3↑ | Overview FID↓ | Overview Skate↓ | Overview Contact↑ | Timeline single R@3↑ | Timeline single FID↓ | Timeline single Skate↓ | Timeline single Contact↑ | Timeline multi R@3↑ | Timeline multi FID↓ | Timeline multi Skate↓ | Timeline multi Contact↑ |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| **Content** Ground Truth | 89.09 | 0.000 | 1.849 | 1.000 | 86.26 | 0.000 | 1.789 | 1.000 | 88.47 | 0.000 | 1.711 | 1.000 |
+| **Content** Kimodo | 81.13 | 0.035 | 4.077 | 0.977 | 73.17 | 0.028 | 3.873 | 0.980 | 80.10 | 0.032 | 3.685 | 0.981 |
+| **Repetition** Ground Truth | 93.91 | 0.000 | 2.106 | 1.000 | 90.13 | 0.000 | 2.037 | 1.000 | 94.49 | 0.000 | 1.931 | 1.000 |
+| **Repetition** Kimodo | 90.92 | 0.004 | 4.573 | 0.972 | 80.38 | 0.007 | 4.442 | 0.976 | 92.58 | 0.006 | 4.199 | 0.974 |
+
+
+### Constrained Evaluation
+
+|  | With text FB Pos↓ | With text EE Pos↓ | With text EE Rot↓ | With text 2D Root↓ | With text Pelvis@95% | Without text FB Pos↓ | Without text EE Pos↓ | Without text EE Rot↓ | Without text 2D Root↓ | Without text Pelvis@95% |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| **Content** Ground Truth | 0.000 | 0.000 | - | 2.362 | 3.30 | 0.000 | 0.000 | - | 2.408 | 3.33 |
+| **Content** Kimodo | 1.316 | 1.762 | - | 3.064 | 5.62 | 1.277 | 1.691 | - | 2.952 | 5.56 |
+| **Repetition** Ground Truth | 0.000 | 0.000 | - | 2.220 | 3.35 | 0.000 | 0.000 | - | 2.195 | 3.34 |
+| **Repetition** Kimodo | 1.226 | 1.778 | - | 2.913 | 5.65 | 1.200 | 1.620 | - | 2.624 | 4.85 |
+
+
+## Kimodo-SOMA-RP-v1.1
+These results are for the Kimodo model trained on the full (proprietary) Bones Rigplay dataset which is a superset of BONES-SEED. Though the training split is larger, the model is not trained on the SEED test splits to ensure a fair comparison.
+
+### Text-Following Evaluation
+
+|  | Overview R@3↑ | Overview FID↓ | Overview Skate↓ | Overview Contact↑ | Timeline single R@3↑ | Timeline single FID↓ | Timeline single Skate↓ | Timeline single Contact↑ | Timeline multi R@3↑ | Timeline multi FID↓ | Timeline multi Skate↓ | Timeline multi Contact↑ |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| **Content** Ground Truth | 89.09 | 0.000 | 1.849 | 1.000 | 86.26 | 0.000 | 1.789 | 1.000 | 88.47 | 0.000 | 1.711 | 1.000 |
+| **Content** Kimodo | 83.32 | 0.025 | 3.641 | 0.982 | 78.08 | 0.026 | 3.523 | 0.984 | 84.79 | 0.028 | 3.278 | 0.985 |
+| **Repetition** Ground Truth | 93.91 | 0.000 | 2.106 | 1.000 | 90.13 | 0.000 | 2.037 | 1.000 | 94.49 | 0.000 | 1.931 | 1.000 |
+| **Repetition** Kimodo | 87.90 | 0.008 | 4.103 | 0.977 | 77.02 | 0.011 | 3.938 | 0.981 | 88.59 | 0.009 | 3.727 | 0.980 |
+
+
+### Constrained Evaluation
+
+|  | With text FB Pos↓ | With text EE Pos↓ | With text EE Rot↓ | With text 2D Root↓ | With text Pelvis@95% | Without text FB Pos↓ | Without text EE Pos↓ | Without text EE Rot↓ | Without text 2D Root↓ | Without text Pelvis@95% |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| **Content** Ground Truth | 0.000 | 0.000 | - | 2.362 | 3.30 | 0.000 | 0.000 | - | 2.408 | 3.33 |
+| **Content** Kimodo | 1.126 | 1.398 | - | 2.819 | 4.78 | 1.129 | 1.382 | - | 2.714 | 4.54 |
+| **Repetition** Ground Truth | 0.000 | 0.000 | - | 2.220 | 3.35 | 0.000 | 0.000 | - | 2.195 | 3.34 |
+| **Repetition** Kimodo | 1.078 | 1.377 | - | 2.621 | 4.69 | 1.088 | 1.370 | - | 2.478 | 4.44 | 
+-->
+
+
+## Quantitative Results
+
+Results are reported for two models:
+
+- **Kimodo-SOMA-SEED-v1.1**:  trained on the public [BONES-SEED](https://huggingface.co/datasets/bones-studio/seed) dataset. The results are comparable to any model trained on SEED that uses our recommended splits [described in the introduction](introduction.md#dataset-splits).
+- **Kimodo-SOMA-RP-v1.1**: trained on the full (proprietary) Bones Rigplay dataset which is a superset of BONES-SEED. Though the training split is larger, the model is not trained on the SEED test splits to ensure a fair comparison.
+
+### Text-Following Evaluation
+
+|  | Overview R@3↑ | Overview FID↓ | Overview Skate↓ | Overview Contact↑ | Timeline single R@3↑ | Timeline single FID↓ | Timeline single Skate↓ | Timeline single Contact↑ | Timeline multi R@3↑ | Timeline multi FID↓ | Timeline multi Skate↓ | Timeline multi Contact↑ |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| **Content** Ground Truth | 89.09 | 0.000 | 1.849 | 1.000 | 86.26 | 0.000 | 1.789 | 1.000 | 88.47 | 0.000 | 1.711 | 1.000 |
+| **Content** Kimodo-SOMA-SEED-v1.1 | 81.13 | 0.035 | 4.077 | 0.977 | 73.17 | 0.028 | 3.873 | 0.980 | 80.10 | 0.032 | 3.685 | 0.981 |
+| **Content** Kimodo-SOMA-RP-v1.1 | 83.32 | 0.025 | 3.641 | 0.982 | 78.08 | 0.026 | 3.523 | 0.984 | 84.79 | 0.028 | 3.278 | 0.985 |
+| **Repetition** Ground Truth | 93.91 | 0.000 | 2.106 | 1.000 | 90.13 | 0.000 | 2.037 | 1.000 | 94.49 | 0.000 | 1.931 | 1.000 |
+| **Repetition** Kimodo-SOMA-SEED-v1.1 | 90.92 | 0.004 | 4.573 | 0.972 | 80.38 | 0.007 | 4.442 | 0.976 | 92.58 | 0.006 | 4.199 | 0.974 |
+| **Repetition** Kimodo-SOMA-RP-v1.1 | 87.90 | 0.008 | 4.103 | 0.977 | 77.02 | 0.011 | 3.938 | 0.981 | 88.59 | 0.009 | 3.727 | 0.980 |
+
+### Constrained Evaluation
+
+|  | With text FB Pos↓ | With text EE Pos↓ | With text EE Rot↓ | With text 2D Root↓ | With text Pelvis@95% | Without text FB Pos↓ | Without text EE Pos↓ | Without text EE Rot↓ | Without text 2D Root↓ | Without text Pelvis@95% |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| **Content** Ground Truth | 0.000 | 0.000 | - | 2.362 | 3.30 | 0.000 | 0.000 | - | 2.408 | 3.33 |
+| **Content** Kimodo-SOMA-SEED-v1.1 | 1.316 | 1.762 | - | 3.064 | 5.62 | 1.277 | 1.691 | - | 2.952 | 5.56 |
+| **Content** Kimodo-SOMA-RP-v1.1 | 1.126 | 1.398 | - | 2.819 | 4.78 | 1.129 | 1.382 | - | 2.714 | 4.54 |
+| **Repetition** Ground Truth | 0.000 | 0.000 | - | 2.220 | 3.35 | 0.000 | 0.000 | - | 2.195 | 3.34 |
+| **Repetition** Kimodo-SOMA-SEED-v1.1 | 1.226 | 1.778 | - | 2.913 | 5.65 | 1.200 | 1.620 | - | 2.624 | 4.85 |
+| **Repetition** Kimodo-SOMA-RP-v1.1 | 1.078 | 1.377 | - | 2.621 | 4.69 | 1.088 | 1.370 | - | 2.478 | 4.44 |

--- a/docs/source/getting_started/quick_start.md
+++ b/docs/source/getting_started/quick_start.md
@@ -11,6 +11,8 @@ Motion generation can be performed with several trained Kimodo models that vary 
 
 | Model | Skeleton | Training Data | Release Date | Hugging Face | License |
 |-------|------|------|-------------|-------------|----|
+| **Kimodo-SOMA-RP-v1.1** | [SOMA](https://github.com/NVlabs/SOMA-X) | [Bones Rigplay 1](https://bones.studio/datasets#rp01) | April 10, 2026 | [Link](https://huggingface.co/nvidia/Kimodo-SOMA-RP-v1.1) | [NVIDIA Open Model](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/) |
+| **Kimodo-SOMA-SEED-v1.1** | [SOMA](https://github.com/NVlabs/SOMA-X) | [BONES-SEED](https://huggingface.co/datasets/bones-studio/seed) | April 10, 2026  | [Link](https://huggingface.co/nvidia/Kimodo-SOMA-SEED-v1.1) | [NVIDIA Open Model](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/) |
 | **Kimodo-SOMA-RP-v1** | [SOMA](https://github.com/NVlabs/SOMA-X) | [Bones Rigplay 1](https://bones.studio/datasets#rp01) | March 16, 2026 | [Link](https://huggingface.co/nvidia/Kimodo-SOMA-RP-v1) | [NVIDIA Open Model](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/) |
 | **Kimodo-G1-RP-v1** | [Unitree G1](https://github.com/unitreerobotics/unitree_mujoco/tree/main/unitree_robots/g1) | [Bones Rigplay 1](https://bones.studio/datasets#rp01) | March 16, 2026  | [Link](https://huggingface.co/nvidia/Kimodo-G1-RP-v1) | [NVIDIA Open Model](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/) |
 | **Kimodo-SOMA-SEED-v1** | [SOMA](https://github.com/NVlabs/SOMA-X) | [BONES-SEED](https://huggingface.co/datasets/bones-studio/seed) | March 16, 2026  | [Link](https://huggingface.co/nvidia/Kimodo-SOMA-SEED-v1) | [NVIDIA Open Model](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/) |
@@ -18,7 +20,7 @@ Motion generation can be performed with several trained Kimodo models that vary 
 | **Kimodo-SMPLX-RP-v1** | [SMPL-X](https://github.com/vchoutas/smplx) | [Bones Rigplay 1](https://bones.studio/datasets#rp01) | March 16, 2026  | [Link](https://huggingface.co/nvidia/Kimodo-SMPLX-RP-v1) | [NVIDIA R&D Model](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-internal-scientific-research-and-development-model-license/) |
 
 By default, we recommend using the models trained on the full Bones Rigplay dataset (700 hours of mocap) for your motion generation needs.
-The models trained on BONES-SEED use 288 hours of [publicly available mocap data](https://huggingface.co/datasets/bones-studio/seed) so are less capable, but are useful for comparing your own trained models on the same dataset. Soon, we will be releasing a benchmark to make it easy to compare motion generation models trained on BONES-SEED.
+The models trained on BONES-SEED use 288 hours of [publicly available mocap data](https://huggingface.co/datasets/bones-studio/seed) so are less capable, but are useful for comparing your own trained models on the same dataset. See the [benchmark](../benchmark/introduction.md) for a standardized evaluation suite on BONES-SEED.
 
 ### Recommended Hardware
 Kimodo requires  ~17GB of VRAM to generate locally, due primarily to the size of the text embedding model.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -62,6 +62,7 @@ user_guide/cli
 user_guide/constraints
 user_guide/output_formats
 user_guide/motion_convert
+user_guide/seed_dataset
 user_guide/configuration
 ```
 
@@ -75,6 +76,17 @@ key_concepts/limitations
 key_concepts/motion_representation
 key_concepts/constraints
 key_concepts/skeleton
+```
+
+```{toctree}
+:maxdepth: 2
+:caption: Benchmark
+:hidden:
+
+benchmark/introduction
+benchmark/pipeline
+benchmark/metrics
+benchmark/results
 ```
 
 ```{toctree}

--- a/docs/source/key_concepts/constraints.md
+++ b/docs/source/key_concepts/constraints.md
@@ -34,6 +34,10 @@ Kimodo is trained to excel at specific types of constraints.
 For SOMA models, constraints may be authored or displayed on the full `somaskel77` skeleton, but Kimodo converts them to the reduced `somaskel30` representation before passing them to the model. See the [skeleton](./skeleton.md) section for more details.
 ```
 
+## Coordinate Space
+
+All constraint values are in a **Y-up** coordinate system with units in **meters**. The model expects constraints relative to a canonical origin where the root starts at XZ = (0, 0) at frame 0. The initial heading can be set via the `first_heading_angle` generation parameter (defaults to 0, facing +Z). See the [constraints JSON format](../user_guide/constraints.md#coordinate-space-and-units) for full details on each field.
+
 ## Time and Scope
 
 In our CLI and demo, constraints can be defined at:

--- a/docs/source/project_info.md
+++ b/docs/source/project_info.md
@@ -8,7 +8,7 @@ If you use this code in your research, please cite:
 @article{Kimodo2026,
   title={Kimodo: Scaling Controllable Human Motion Generation},
   author={Rempe, Davis and Petrovich, Mathis and Yuan, Ye and Zhang, Haotian and Peng, Xue Bin and Jiang, Yifeng and Wang, Tingwu and Iqbal, Umar and Minor, David and de Ruyter, Michael and Li, Jiefeng and Tessler, Chen and Lim, Edy and Jeong, Eugene and Wu, Sam and Hassani, Ehsan and Huang, Michael and Yu, Jin-Bey and Chung, Chaeyeon and Song, Lina and Dionne, Olivier and Kautz, Jan and Yuen, Simon and Fidler, Sanja},
-  journal={arXiv},
+  journal={arXiv:2603.15546},
   year={2026}
 }
 ```

--- a/docs/source/project_structure.md
+++ b/docs/source/project_structure.md
@@ -82,6 +82,12 @@ kimodo/
 │   ├── sanitize.py               # Input sanitization
 │   ├── assets.py                 # Asset path resolution
 │   └── tools.py                  # General utilities
+├── benchmark/                    # Evaluation pipeline scripts
+│   ├── create_benchmark.py       # Step 1: Build test suite from SEED + metadata
+│   ├── generate_eval.py          # Step 2: Generate motions for test suite
+│   ├── embed_folder.py           # Step 3: Embed motions and text with TMR
+│   ├── evaluate_folder.py        # Step 4: Compute metrics for test cases
+│   └── parse_folder.py           # Step 5: Aggregate and display results
 ├── MotionCorrection/             # Optional C++/Python post-processing
 │   ├── python/motion_correction/ # Python bindings
 │   └── src/cpp/                  # C++ implementation

--- a/docs/source/user_guide/cli.md
+++ b/docs/source/user_guide/cli.md
@@ -42,6 +42,19 @@ kimodo_gen "A person walks forward and picks something up from the ground." \
 Constraint files can be created and saved from the interactive demo or manually defined following
 the [constraints format guide](constraints.md).
 
+## Output Formats
+
+For full details on output formats, see [this page](output_formats.md).
+
+To convert between these formats offline, see [Motion format conversion](motion_convert.md) (`kimodo_convert`).
+
+CLI generation uses a single **output stem** (`--output`) for all formats (NPZ, AMASS NPZ, CSV, and BVH). It can write either **one file** or **a folder of files**, depending on the number of samples:
+
+- **One sample** (`--num_samples 1`): writes a single file per format at the stem (e.g. `--output test` → `test.npz`, `test.csv`). No folder is created. For SMPLX, AMASS is written to `test_amass.npz`.
+- **Multiple samples**: creates a folder with that stem and writes one file per sample with suffixes `_00`, `_01`, etc. (e.g. `--output test` → `test/test_00.npz`, ...).
+
+Use the `--bvh` flag to also export BVH (SOMA only) to the same stem.
+
 ## Visualizing Generated Motions
 
 Motions generated with the CLI can be visualized in the demo UI. To do this, under "Load/Save" > "Motion", type in the path of the generated output npz file, then click "Load Motion" to load it into the viewer. If you used constraints when generating, those can also be loaded in in a similar way.

--- a/docs/source/user_guide/constraints.md
+++ b/docs/source/user_guide/constraints.md
@@ -1,7 +1,7 @@
 # Constraints JSON Format
 
 The `--constraints` flag in the CLI expects a JSON file containing a list of constraint objects.
-It is easiest to look at the examples provided with the demo to see how thse are formatted. These can be seen for various model types in `kimodo/assets/demo/examples`.
+It is easiest to look at the examples provided with the demo to see how these are formatted. These can be seen for various model types in `kimodo/assets/demo/examples`.
 
 > Tip: the easiest way to get a valid constraints file is to create constraints in the interactive demo and to click on `Save Constraints`.
 
@@ -18,8 +18,38 @@ It is easiest to look at the examples provided with the demo to see how thse are
 For SOMA models, constraints may be authored or displayed on the full `somaskel77` skeleton, but Kimodo converts them to the reduced `somaskel30` representation before passing them to the model. See the [skeleton](../key_concepts/skeleton.md) section for more details.
 ```
 
+## Coordinate Space and Units
+
+All spatial values in constraints use the same coordinate system as Kimodo's internal motion representation:
+
+- **Axes**: **Y-up**, with locomotion on the **XZ ground plane**. The Y axis points up, X and Z span the horizontal ground plane.
+- **Units**: **Meters**. Joint positions, root translations, and 2D root coordinates are all in meters.
+
+### Canonicalization
+
+During training, every motion is *canonicalized* so that the (smoothed) root starts at the XZ origin `(0, 0)` at frame 0.
+The initial body heading (facing direction) is randomly rotated and passed to the model as an explicit input (`first_heading_angle`), so the model is robust to arbitrary initial orientations.
+
+At inference, constraints should be authored **relative to this canonical origin**:
+- `smooth_root_2d` values at frame 0 should be at `(0, 0)`, with subsequent frames expressing displacement from there.
+- `root_positions` XZ components follow the same convention; Y is the **absolute hip height above the ground** (typically ~0.9 m for a standing pose, lower for crouching/sitting).
+- `first_heading_angle` (a generation parameter, not part of the constraints JSON) defaults to `0.0` radians (facing +Z) but can be set to any value to change the initial facing direction.
+
+### Field-specific notes
+
+| Field | Space | Notes |
+|-------|-------|-------|
+| `smooth_root_2d` | `[x, z]` ground plane (meters) | Relative to the canonical origin. |
+| `root_positions` | `[x, y, z]` (meters) | Y is absolute hip height above ground. XZ relative to canonical origin. |
+| `global_root_heading` | `[cos(θ), sin(θ)]` | **Not** a raw radian value — must be a 2-element cosine/sine pair per frame (i.e. the heading direction vector). |
+| `local_joints_rot` | axis-angle (radians) | Local joint rotations in the skeleton's rest-pose frame. |
+
+### Constraints not at frame 0
+
+Adding a constraint at frame 0 is **not** required. If the first constrained frame is later in the sequence (e.g. frame 45), Kimodo generates the initial frames freely from its learned distribution, starting near XZ = (0, 0) with the heading set by `first_heading_angle`. The constraint just needs to be reachable from that starting configuration given the text prompt and motion duration.
+
 ## Constraint Types
-Depending on `type`, additional fields are required or optional. All numeric arrays are plain nested JSON lists. In the following definitions `T` is the number of frames and `J` is the number of skeleton joints.
+Depending on `type`, additional fields are required or optional. All numeric arrays are plain nested JSON lists. In the following definitions `T` is the number of constrainted frames (i.e., number of `frame_indices`) and `J` is the number of skeleton joints.
 
 
 ### `root2d`
@@ -37,12 +67,23 @@ This captures full-body keyframe constraints on joint positions. It includes:
 - `root_positions` (array shaped `[T, 3]`): Root (hips) translation `[x, y, z]`.
 - `smooth_root_2d` (optional; array of `[T, 2]`): Smoothed root positions `[x, z]`. If omitted, it is taken as the `[x, z]` components of `root_positions`.
 
+Note the `local_joint_rot` will not explicitly be constrained, the constraint will be on the joint positions that results from FK with the given joint rotations.
+
 ### `left-hand` / `right-hand` / `left-foot` / `right-foot`
-Captures end-effector constraints on the hand/feet joint positions and rotations.
+Captures end-effector constraints on the hand/feet joint positions and global rotations.
 
-These use the same fields as `fullbody`. However, under the hood these will only affect the corresponding end-effectors and hips.
+These use the same fields as `fullbody`. However, under the hood these will only affect the corresponding end-effectors and hips. Each of these types is a shorthand for `end-effector` with pre-set joint names.
 
-## Minimal Example
+### `end-effector`
+A general end-effector constraint that requires an additional field:
+
+- `joint_names` (array of strings): Which end-effectors to constrain (e.g. `["left_hand"]`, `["right_foot", "left_foot"]`). Available names depend on the skeleton; see the skeleton's `expand_joint_names()` for the full mapping.
+
+Otherwise uses the same fields as `fullbody` (`local_joints_rot`, `root_positions`, optional `smooth_root_2d`).
+
+## Examples
+
+### Root 2D waypoints
 
 ```json
 [
@@ -53,3 +94,18 @@ These use the same fields as `fullbody`. However, under the hood these will only
   }
 ]
 ```
+
+### Full-body keyframe
+
+```json
+[
+  {
+    "type": "fullbody",
+    "frame_indices": [60],
+    "root_positions": [[0.0, 0.96, 1.5]],
+    "local_joints_rot": [[[0.0, 0.0, 0.0], "... one [3] per joint ..."]]
+  }
+]
+```
+
+Here `root_positions` places the hips at x=0, y=0.96 m (standing height), z=1.5 m forward from the origin. `local_joints_rot` is a `[T, J, 3]` array of axis-angle rotations for every joint in the skeleton.

--- a/docs/source/user_guide/output_formats.md
+++ b/docs/source/user_guide/output_formats.md
@@ -1,12 +1,5 @@
 # Output Formats
 
-CLI generation uses a single **output stem** (`--output`) for all formats (NPZ, AMASS NPZ, CSV, and BVH). It can write either **one file** or **a folder of files**, depending on the number of samples:
-
-- **One sample** (`--num_samples 1`): writes a single file per format at the stem (e.g. `--output test` → `test.npz`, `test.csv`). No folder is created. For SMPLX, AMASS is written to `test_amass.npz`.
-- **Multiple samples**: creates a folder with that stem and writes one file per sample with suffixes `_00`, `_01`, etc. (e.g. `--output test` → `test/test_00.npz`, ...).
-
-Use the `--bvh` flag to also export BVH (SOMA only) to the same stem.
-
 ## Converting Between Formats
 
 To convert between the formats described below, see [Motion format conversion](motion_convert.md) (`kimodo_convert`).

--- a/docs/source/user_guide/seed_dataset.md
+++ b/docs/source/user_guide/seed_dataset.md
@@ -1,0 +1,90 @@
+# Loading BONES-SEED BVH data
+
+The [BONES-SEED dataset](https://huggingface.co/datasets/bones-studio/seed) is a publicly available optical motion-capture dataset distributed as BVH files with the [SOMA 77-joint skeleton](../key_concepts/skeleton.md). This page walks through the steps to parse a SEED BVH file and convert it into Kimodo's internal motion representation.
+
+This is a similar pipeline used by the benchmark to extract ground-truth motions from SEED data (see the [benchmark pipeline](../benchmark/pipeline.md)).
+
+## Step-by-Step Conversion
+
+### 1. Parse the BVH file
+
+`parse_bvh_motion` reads a BVH file and returns local joint rotation matrices, root translation (in meters), and the source frame rate.
+
+```python
+from kimodo.skeleton.bvh import parse_bvh_motion
+
+local_rot_mats, root_trans, bvh_fps = parse_bvh_motion(bvh_path)
+```
+
+### 2. Subsample to 30 FPS
+
+Kimodo operates at 30 Hz. If the source BVH has a different frame rate (120 FPS for BONES-SEED), subsample by striding:
+
+```python
+fps = 30
+step = round(bvh_fps / fps)
+root_trans = root_trans[::step]
+local_rot_mats = local_rot_mats[::step]
+```
+
+### 3. Convert to the standard T-pose
+
+The SEED BVH rest pose differs from Kimodo's canonical T-pose. The `to_standard_tpose` function remaps the local rotations accordingly and returns both local and global rotation matrices:
+
+```python
+from kimodo.skeleton import SOMASkeleton77
+
+skeleton = SOMASkeleton77()
+local_rot_mats, global_rot_mats = skeleton.to_standard_tpose(local_rot_mats)
+```
+
+### 4. Compute Kimodo motion features
+
+Build the motion feature tensor used by the model. The feature layout is described in [Motion representation](../key_concepts/motion_representation.md).
+
+```python
+from kimodo.motion_rep import KimodoMotionRep
+
+motion_rep = KimodoMotionRep(skeleton, fps)
+feats = motion_rep(local_rot_mats, root_trans, to_normalize=False)
+```
+
+### 5. Canonicalize (optionally) and recover the motion dictionary
+
+Canonicalize so that the motion starts at the origin facing +Z, then invert the features back into a full motion dictionary:
+
+```python
+can_feats = motion_rep.canonicalize(feats)
+motion_dict = motion_rep.inverse(can_feats, is_normalized=False)
+```
+
+`motion_dict` is a dictionary with keys such as `local_rot_mats`, `global_rot_mats`, `posed_joints`, `root_positions`, `smooth_root_pos`, `foot_contacts`, etc. See [Output formats](output_formats.md) for details on the Kimodo NPZ layout.
+
+## Full script
+
+```python
+from kimodo.motion_rep import KimodoMotionRep
+from kimodo.skeleton import SOMASkeleton77
+from kimodo.skeleton.bvh import parse_bvh_motion
+
+# 1. Parse BVH
+local_rot_mats, root_trans, bvh_fps = parse_bvh_motion(bvh_path)
+
+# 2. Subsample to 30 fps
+fps = 30
+step = round(bvh_fps / fps)
+root_trans = root_trans[::step]
+local_rot_mats = local_rot_mats[::step]
+
+# 3. Convert to standard T-pose
+skeleton = SOMASkeleton77()
+local_rot_mats, global_rot_mats = skeleton.to_standard_tpose(local_rot_mats)
+
+# 4. Compute motion features
+motion_rep = KimodoMotionRep(skeleton, fps)
+feats = motion_rep(local_rot_mats, root_trans, to_normalize=False)
+
+# 5. Canonicalize and get the full motion dictionary
+can_feats = motion_rep.canonicalize(feats)
+motion_dict = motion_rep.inverse(can_feats, is_normalized=False)
+```

--- a/kimodo/metrics/foot_skate.py
+++ b/kimodo/metrics/foot_skate.py
@@ -17,6 +17,17 @@ from kimodo.tools import ensure_batched
 from .base import Metric
 
 
+def get_four_contacts(fidx: list):
+    if len(fidx) == 4:
+        return fidx
+    if len(fidx) == 6:
+        # For soma77
+        # remove "LeftToeEnd" and "RightToeEnd"
+        fidx = fidx[:2] + fidx[3:5]
+        return fidx
+    raise ValueError("Expects 4 or 6 foot joints (heel/toe per foot)")
+
+
 class FootSkateFromHeight(Metric):
     """When toe joint is near the floor, measures mean velocity of the toes."""
 
@@ -40,8 +51,7 @@ class FootSkateFromHeight(Metric):
         **kwargs,
     ) -> Dict:
         fidx = self.skeleton.foot_joint_idx
-        if len(fidx) != 4:
-            raise ValueError("FootSkateFromHeight expects four foot joints (heel/toe per foot)")
+        fidx = get_four_contacts(fidx)
 
         feet_pos = posed_joints[:, :, fidx]
         toe_pos = feet_pos[:, :, [1, 3]]
@@ -89,9 +99,16 @@ class FootSkateFromContacts(Metric):
         **kwargs,
     ) -> Dict:
         fidx = self.skeleton.foot_joint_idx
+        fidx = get_four_contacts(fidx)
+
         feet_pos = posed_joints[:, :, fidx]
         dt = 1.0 / self.fps
         foot_vel = torch.norm(feet_pos[:, 1:] - feet_pos[:, :-1], dim=-1) / dt
+
+        if foot_contacts.shape[-1] == 6:
+            # For soma77
+            # remove "LeftToeEnd" and "RightToeEnd"
+            foot_contacts = foot_contacts[..., [0, 1, 3, 4]]
 
         foot_contacts = foot_contacts[:, :-1]
         vel_err = foot_vel * foot_contacts
@@ -146,7 +163,7 @@ class FootSkateRatio(Metric):
         **kwargs,
     ) -> Dict:
         fidx = self.skeleton.foot_joint_idx
-        assert len(fidx) == 4, "This metric assumes 4 foot joints: heel, toe, heel, toe"
+        fidx = get_four_contacts(fidx)
 
         feet_pos = posed_joints[:, :, fidx]
         toe_pos = feet_pos[:, :, [1, 3]]
@@ -215,7 +232,11 @@ class FootContactConsistency(Metric):
             self.height_thresh,
         )
 
-        # compute accuracy of predicted, treating heuristic as ground truth
+        if foot_contacts.shape[-1] == 6:
+            # For soma77
+            # remove "LeftToeEnd" and "RightToeEnd"
+            foot_contacts = foot_contacts[..., [0, 1, 3, 4]]
+
         num_contacts = foot_contacts.shape[-1]
         incorrect = torch.logical_xor(heuristic_contacts, foot_contacts)
         # account for generated length

--- a/kimodo/metrics/tmr.py
+++ b/kimodo/metrics/tmr.py
@@ -282,9 +282,12 @@ class TMR_EmbeddingMetric(Metric):
         )
         for key, val in t2m_metrics.items():
             output["TMR/t2m_R/" + key] = val
-        mu_gen, cov_gen = calculate_activation_statistics(motion_gen_latents)
-        mu_text, cov_text = calculate_activation_statistics(text_latents)
-        output["TMR/FID/gen_text"] = calculate_frechet_distance(mu_gen, cov_gen, mu_text, cov_text)
+        if batch_size >= 2:
+            mu_gen, cov_gen = calculate_activation_statistics(motion_gen_latents)
+            mu_text, cov_text = calculate_activation_statistics(text_latents)
+            output["TMR/FID/gen_text"] = calculate_frechet_distance(mu_gen, cov_gen, mu_text, cov_text)
+        else:
+            output["TMR/FID/gen_text"] = float("nan")
         if self.saved_motion_gt_latents:
             motion_gt_latents = np.concatenate(self.saved_motion_gt_latents)
             assert motion_gt_latents.shape == motion_gen_latents.shape
@@ -306,9 +309,13 @@ class TMR_EmbeddingMetric(Metric):
             )
             for key, val in t2gm_metrics.items():
                 output["TMR/t2m_gt_R/" + key] = val
-            mu_gt_motion, cov_gt_motion = calculate_activation_statistics(motion_gt_latents)
-            output["TMR/FID/gen_gt"] = calculate_frechet_distance(mu_gen, cov_gen, mu_gt_motion, cov_gt_motion)
-            output["TMR/FID/gt_text"] = calculate_frechet_distance(mu_gt_motion, cov_gt_motion, mu_text, cov_text)
+            if batch_size >= 2:
+                mu_gt_motion, cov_gt_motion = calculate_activation_statistics(motion_gt_latents)
+                output["TMR/FID/gen_gt"] = calculate_frechet_distance(mu_gen, cov_gen, mu_gt_motion, cov_gt_motion)
+                output["TMR/FID/gt_text"] = calculate_frechet_distance(mu_gt_motion, cov_gt_motion, mu_text, cov_text)
+            else:
+                output["TMR/FID/gen_gt"] = float("nan")
+                output["TMR/FID/gt_text"] = float("nan")
         for key, val in output.items():
             if isinstance(val, (int, float, np.integer, np.floating)):
                 val = torch.tensor([val for _ in range(batch_size)])
@@ -341,9 +348,13 @@ def compute_tmr_retrieval_metrics(
     for key, val in t2m_metrics.items():
         output[f"TMR/t2m_R/{key}"] = float(val)
 
-    mu_gen, cov_gen = calculate_activation_statistics(motion_emb)
-    mu_text, cov_text = calculate_activation_statistics(text_emb)
-    output["TMR/FID/gen_text"] = float(calculate_frechet_distance(mu_gen, cov_gen, mu_text, cov_text))
+    n_samples = len(motion_emb)
+    if n_samples >= 2:
+        mu_gen, cov_gen = calculate_activation_statistics(motion_emb)
+        mu_text, cov_text = calculate_activation_statistics(text_emb)
+        output["TMR/FID/gen_text"] = float(calculate_frechet_distance(mu_gen, cov_gen, mu_text, cov_text))
+    else:
+        output["TMR/FID/gen_text"] = float("nan")
 
     if gt_motion_emb is not None:
         if gt_motion_emb.shape != motion_emb.shape:
@@ -370,9 +381,13 @@ def compute_tmr_retrieval_metrics(
         for key, val in t2gm_metrics.items():
             output[f"TMR/t2m_gt_R/{key}"] = float(val)
 
-        mu_gt_motion, cov_gt_motion = calculate_activation_statistics(gt_motion_emb)
-        output["TMR/FID/gen_gt"] = float(calculate_frechet_distance(mu_gen, cov_gen, mu_gt_motion, cov_gt_motion))
-        output["TMR/FID/gt_text"] = float(calculate_frechet_distance(mu_gt_motion, cov_gt_motion, mu_text, cov_text))
+        if n_samples >= 2:
+            mu_gt_motion, cov_gt_motion = calculate_activation_statistics(gt_motion_emb)
+            output["TMR/FID/gen_gt"] = float(calculate_frechet_distance(mu_gen, cov_gen, mu_gt_motion, cov_gt_motion))
+            output["TMR/FID/gt_text"] = float(calculate_frechet_distance(mu_gt_motion, cov_gt_motion, mu_text, cov_text))
+        else:
+            output["TMR/FID/gen_gt"] = float("nan")
+            output["TMR/FID/gt_text"] = float("nan")
 
     return output
 

--- a/kimodo/model/llm2vec/llm2vec_wrapper.py
+++ b/kimodo/model/llm2vec/llm2vec_wrapper.py
@@ -19,6 +19,7 @@ class LLM2VecEncoder:
         peft_model_name_or_path: str,
         dtype: str,
         llm_dim: int,
+        device: str = "auto",
     ) -> None:
         torch_dtype = getattr(torch, dtype)
         self.llm_dim = llm_dim
@@ -34,6 +35,7 @@ class LLM2VecEncoder:
             peft_model_name_or_path=peft_model_name_or_path,
             torch_dtype=torch_dtype,
             cache_dir=cache_dir,
+            device_map=device,
         )
         self.model.eval()
         for p in self.model.parameters():
@@ -57,7 +59,16 @@ class LLM2VecEncoder:
             is_string = True
 
         with torch.no_grad():
-            encoded_text = self.model.encode(text, batch_size=len(text), show_progress_bar=False)
+            encoded_text = self.model.encode(
+                text,
+                # IMPORTANT: different batch sizes unexpectedly change the output embeddings, so we always set it to 1
+                #            here for repeatability no matter how many texts are being encoded. This
+                #            is a fundamental issue with transformers, and is especially bad at lower
+                #            precisions (https://github.com/huggingface/transformers/issues/25420#issuecomment-1775317535)
+                #            note: this is an internal batch size used by llm2vec - the text list can still be of arbitrary length.
+                batch_size=1,
+                show_progress_bar=False,
+            )
 
         assert len(encoded_text.shape)
         assert self.llm_dim == encoded_text.shape[-1]

--- a/kimodo/model/load_model.py
+++ b/kimodo/model/load_model.py
@@ -28,6 +28,7 @@ TEXT_ENCODER_PRESETS = {
             "peft_model_name_or_path": "McGill-NLP/LLM2Vec-Meta-Llama-3-8B-Instruct-mntp-supervised",
             "dtype": "bfloat16",
             "llm_dim": 4096,
+            "device": "auto",
         },
     }
 }
@@ -64,27 +65,29 @@ def _build_api_text_encoder_conf(text_encoder_url: str) -> dict:
     }
 
 
-def _build_local_text_encoder_conf() -> dict:
+def _build_local_text_encoder_conf(text_encoder_fp32: bool = False) -> dict:
     text_encoder_name = get_env_var("TEXT_ENCODER", DEFAULT_TEXT_ENCODER)
     if text_encoder_name not in TEXT_ENCODER_PRESETS:
         available = ", ".join(sorted(TEXT_ENCODER_PRESETS))
         raise ValueError(f"Unknown TEXT_ENCODER='{text_encoder_name}'. Available: {available}")
 
     preset = TEXT_ENCODER_PRESETS[text_encoder_name]
+    if text_encoder_fp32:
+        preset["kwargs"]["dtype"] = "float32"
     return {
         "_target_": preset["target"],
         **preset["kwargs"],
     }
 
 
-def _select_text_encoder_conf(text_encoder_url: str) -> dict:
+def _select_text_encoder_conf(text_encoder_url: str, text_encoder_fp32: bool = False) -> dict:
     # TEXT_ENCODER_MODE options:
     # - "api": force TextEncoderAPI
     # - "local": force local LLM2VecEncoder
     # - "auto": try API first, fallback to local if unreachable
     mode = get_env_var("TEXT_ENCODER_MODE", "auto").lower()
     if mode == "local":
-        return _build_local_text_encoder_conf()
+        return _build_local_text_encoder_conf(text_encoder_fp32)
     if mode == "api":
         return _build_api_text_encoder_conf(text_encoder_url)
 
@@ -99,7 +102,7 @@ def _select_text_encoder_conf(text_encoder_url: str) -> dict:
             "Text encoder service is unreachable, falling back to local LLM2Vec "
             f"encoder. ({type(error).__name__}: {error})"
         )
-        return _build_local_text_encoder_conf()
+        return _build_local_text_encoder_conf(text_encoder_fp32)
 
 
 def load_model(
@@ -109,6 +112,7 @@ def load_model(
     default_family: Optional[str] = "Kimodo",
     return_resolved_name: bool = False,
     text_encoder=None,
+    text_encoder_fp32: bool = False,
 ):
     """Load a kimodo model by name (e.g. 'g1', 'soma').
 
@@ -129,6 +133,7 @@ def load_model(
             return only the model.
         text_encoder: Pre-built text encoder to reuse. When provided, skips
             text encoder selection/instantiation entirely.
+        text_encoder_fp32: If True, uses fp32 for the text encoder rather than default bfloat16.
 
     Returns:
         Loaded model in eval mode, or (model, resolved short key) if
@@ -186,7 +191,7 @@ def load_model(
         runtime_conf = OmegaConf.create(
             {
                 "checkpoint_dir": str(model_path),
-                "text_encoder": _select_text_encoder_conf(text_encoder_url),
+                "text_encoder": _select_text_encoder_conf(text_encoder_url, text_encoder_fp32),
             }
         )
 

--- a/kimodo/model/registry.py
+++ b/kimodo/model/registry.py
@@ -14,9 +14,11 @@ from typing import Optional
 # Parser expects: org/Family-SKELETON-DATASET-version (e.g. Kimodo-SOMA-RP-v1).
 KIMODO_REPO_IDS = [
     "nvidia/Kimodo-SOMA-RP-v1",
+    "nvidia/Kimodo-SOMA-RP-v1.1",
     "nvidia/Kimodo-SMPLX-RP-v1",
     "nvidia/Kimodo-G1-RP-v1",
     "nvidia/Kimodo-SOMA-SEED-v1",
+    "nvidia/Kimodo-SOMA-SEED-v1.1",
     "nvidia/Kimodo-G1-SEED-v1",
 ]
 TMR_REPO_IDS = [
@@ -24,7 +26,7 @@ TMR_REPO_IDS = [
 ]
 
 # Repo ID without org, for display (e.g. Kimodo-SOMA-RP-v1).
-_REPO_NAME_PATTERN = re.compile(r"^(Kimodo|TMR)-([A-Za-z0-9]+)-(RP|SEED)-v(\d+)$")
+_REPO_NAME_PATTERN = re.compile(r"^(Kimodo|TMR)-([A-Za-z0-9]+)-(RP|SEED)-v(\d+(?:\.\d+)*)$")
 
 
 @dataclass
@@ -73,20 +75,27 @@ def _parse_repo_id(repo_id: str) -> Optional[ModelInfo]:
     )
 
 
+def _version_tuple(v: str) -> tuple[int, ...]:
+    """Parse 'vN' or 'vN.M' into a comparable tuple of ints."""
+    if v.startswith("v"):
+        parts = v[1:].split(".")
+        if all(p.isdigit() for p in parts):
+            return tuple(int(p) for p in parts)
+    return (0,)
+
+
+def _version_key(info: ModelInfo) -> tuple[int, ...]:
+    return _version_tuple(info.version)
+
+
 def _build_registry() -> tuple[list[ModelInfo], dict[str, str], list[str]]:
     """Build model infos, short_key -> repo_id map, and list of short keys.
 
-    When multiple versions exist for the same (family, skeleton, dataset), the base short_key (e.g.
-    kimodo-soma-rp) maps to the latest version's repo_id so that HF resolution finds the newest
-    model.
+    When multiple versions exist for the same (family, skeleton, dataset), each ModelInfo gets a
+    version-specific short_key (e.g. kimodo-soma-rp-v1, kimodo-soma-rp-v2) and a versionless alias
+    (kimodo-soma-rp) is added to MODEL_NAMES pointing to the latest version.  When only one version
+    exists, the short_key stays versionless (e.g. kimodo-smplx-rp).
     """
-
-    def _version_key(info: ModelInfo) -> int:
-        v = info.version
-        if v.startswith("v") and v[1:].isdigit():
-            return int(v[1:])
-        return 0
-
     all_repos = KIMODO_REPO_IDS + TMR_REPO_IDS
     infos: list[ModelInfo] = []
     for repo_id in all_repos:
@@ -95,19 +104,27 @@ def _build_registry() -> tuple[list[ModelInfo], dict[str, str], list[str]]:
             raise ValueError(f"Registry repo ID does not match expected pattern: {repo_id}")
         infos.append(info)
 
-    # Map each base short_key to the latest version's repo_id (by version number)
-    model_names: dict[str, str] = {}
-    seen_short_keys: set[str] = set()
+    # Group by base short_key to detect multi-version families.
+    base_groups: dict[str, list[ModelInfo]] = {}
     for info in infos:
-        if info.short_key in seen_short_keys:
-            continue
-        seen_short_keys.add(info.short_key)
-        candidates = [
-            i for i in infos if i.family == info.family and i.skeleton == info.skeleton and i.dataset == info.dataset
-        ]
-        if candidates:
-            latest = max(candidates, key=_version_key)
-            model_names[info.short_key] = latest.repo_id
+        base_groups.setdefault(info.short_key, []).append(info)
+
+    # For groups with multiple versions, make each short_key version-specific.
+    for base_key, group in base_groups.items():
+        if len(group) > 1:
+            for info in group:
+                info.short_key = f"{base_key}-{info.version}"
+
+    # Map each (now unique) short_key to its repo_id.
+    model_names: dict[str, str] = {}
+    for info in infos:
+        model_names[info.short_key] = info.repo_id
+
+    # Add versionless aliases for multi-version groups, pointing to the latest.
+    for base_key, group in base_groups.items():
+        if len(group) > 1:
+            latest = max(group, key=_version_key)
+            model_names[base_key] = latest.repo_id
 
     return infos, model_names, list(model_names.keys())
 
@@ -120,7 +137,14 @@ KIMODO_MODELS = [info.short_key for info in MODEL_INFOS if info.family == "Kimod
 TMR_MODELS = [info.short_key for info in MODEL_INFOS if info.family == "TMR"]
 
 # Backward compatibility: FRIENDLY_NAMES for any code that still expects it.
+# Includes versioned short_keys and versionless aliases (latest display name).
 FRIENDLY_NAMES = {info.short_key: info.display_name for info in MODEL_INFOS}
+for _key, _repo_id in MODEL_NAMES.items():
+    if _key not in FRIENDLY_NAMES:
+        for _info in MODEL_INFOS:
+            if _info.repo_id == _repo_id:
+                FRIENDLY_NAMES[_key] = _info.display_name
+                break
 
 DEFAULT_MODEL = "kimodo-soma-rp"
 DEFAULT_TEXT_ENCODER_URL = "http://127.0.0.1:9550/"
@@ -237,13 +261,7 @@ def get_versions_for_dataset_skeleton(dataset_ui_label: str, skeleton: str) -> l
         if info.dataset == dataset and info.skeleton == skeleton:
             versions.append(info.version)
 
-    # Sort by numeric part so v2 comes after v1.
-    def version_key(v: str) -> int:
-        if v.startswith("v") and v[1:].isdigit():
-            return int(v[1:])
-        return 0
-
-    return sorted(set(versions), key=version_key)
+    return sorted(set(versions), key=_version_tuple)
 
 
 def get_models_for_dataset_skeleton(
@@ -259,13 +277,7 @@ def get_models_for_dataset_skeleton(
     if family is not None:
         infos = [i for i in infos if i.family == family]
 
-    def version_key(info: ModelInfo) -> int:
-        v = info.version
-        if v.startswith("v") and v[1:].isdigit():
-            return int(v[1:])
-        return 0
-
-    return sorted(infos, key=version_key, reverse=True)
+    return sorted(infos, key=_version_key, reverse=True)
 
 
 def resolve_to_short_key(dataset_ui_label: str, skeleton: str, version: str) -> Optional[str]:
@@ -311,14 +323,7 @@ def _get_latest_for_family_skeleton_dataset(family: str, skeleton: str, dataset:
     ]
     if not candidates:
         return None
-
-    def version_key(info: ModelInfo) -> int:
-        v = info.version
-        if v.startswith("v") and v[1:].isdigit():
-            return int(v[1:])
-        return 0
-
-    return max(candidates, key=version_key)
+    return max(candidates, key=_version_key)
 
 
 def kimodo_short_key_for_skeleton_dataset(skeleton: str, dataset: str) -> Optional[str]:
@@ -341,12 +346,12 @@ def registry_skeleton_for_joint_count(nb_joints: int) -> str:
 
 # Optional version: Family-Skeleton-Dataset-vN or Family-Skeleton-Dataset
 _RESOLVE_FULL_PATTERN = re.compile(
-    r"^(Kimodo|TMR|kimodo|tmr)[\-_]" r"([A-Za-z0-9]+)[\-_]" r"(RP|SEED|rp|seed)" r"(?:[\-_]v(\d+))?$",
+    r"^(Kimodo|TMR|kimodo|tmr)[\-_]" r"([A-Za-z0-9]+)[\-_]" r"(RP|SEED|rp|seed)" r"(?:[\-_]v(\d+(?:\.\d+)*))?$",
     re.IGNORECASE,
 )
 # Partial: Skeleton-Dataset or Skeleton or Dataset (no family)
 _RESOLVE_PARTIAL_PATTERN = re.compile(
-    r"^([A-Za-z0-9]+)(?:[\-_](RP|SEED|rp|seed))?(?:[\-_]v(\d+))?$",
+    r"^([A-Za-z0-9]+)(?:[\-_](RP|SEED|rp|seed))?(?:[\-_]v(\d+(?:\.\d+)*))?$",
     re.IGNORECASE,
 )
 

--- a/kimodo/model/tmr.py
+++ b/kimodo/model/tmr.py
@@ -331,6 +331,7 @@ class TMR(nn.Module):
         with convert_ctx:
             features = self.motion_rep(
                 posed_joints=posed_joints,
+                to_canonicalize=True,
                 to_normalize=True,
                 lengths=lengths,
             )

--- a/kimodo/motion_rep/feature_utils.py
+++ b/kimodo/motion_rep/feature_utils.py
@@ -183,7 +183,7 @@ class RotateFeatures:
         self.corrective_mat_Y = torch.stack((cos, zero, sin, zero, one, zero, -sin, zero, cos), -1).reshape(
             angle.shape + (3, 3)
         )
-        self.corrective_mat_Y_T = self.corrective_mat_Y.transpose(1, 2).contiguous()
+        self.corrective_mat_Y_T = self.corrective_mat_Y.transpose(-2, -1).contiguous()
 
     def rotate_positions(self, positions: torch.Tensor):
         """Rotate 3D positions around the Y axis."""

--- a/kimodo/motion_rep/reps/base.py
+++ b/kimodo/motion_rep/reps/base.py
@@ -74,7 +74,13 @@ class MotionRepBase:
             self.global_root_stats = Stats(os.path.join(stats_path, "global_root"))
             self.local_root_stats = Stats(os.path.join(stats_path, "local_root"))
             self.body_stats = Stats(os.path.join(stats_path, "body"))
-            # self.stats not set; normalize/unnormalize apply per-part below
+
+            # Global stats
+            mean = torch.cat([self.global_root_stats.mean, self.body_stats.mean])
+            std = torch.cat([self.global_root_stats.std, self.body_stats.std])
+            assert len(mean) == len(std) == self.motion_rep_dim, "There is an stat issue."
+            self.stats = Stats()
+            self.stats.register_from_tensors(mean, std)
 
     def get_root_pos(self, features: torch.Tensor, fallback_to_smooth: bool = True):
         """Extract root positions from a feature tensor.
@@ -224,30 +230,23 @@ class MotionRepBase:
         return self.translate_2d_to(features, target_2d_pos, return_delta_pos=return_delta_pos)
 
     @ensure_batched(features=3)
-    def canonicalize(self, features: torch.Tensor):
+    def canonicalize(self, features: torch.Tensor, normalized: bool = False):
         """Canonicalize heading and planar position at frame 0."""
+        if normalized:
+            features = self.unnormalize(features)
         rotated_features = self.rotate_to_zero(features)
-        return self.translate_2d_to_zero(rotated_features)
+        canonicalized_features = self.translate_2d_to_zero(rotated_features)
+        if normalized:
+            canonicalized_features = self.normalize(canonicalized_features)
+        return canonicalized_features
 
     def normalize(self, features):
-        """Normalize features using per-part stats (global_root, local_root, body)."""
-        gr = slice(0, self.global_root_dim)
-        lr = slice(self.global_root_dim, self.global_root_dim + self.local_root_dim)
-        out = torch.empty_like(features, device=features.device, dtype=features.dtype)
-        out[..., gr] = self.global_root_stats.normalize(features[..., gr])
-        out[..., lr] = self.local_root_stats.normalize(features[..., lr])
-        out[..., self.body_slice] = self.body_stats.normalize(features[..., self.body_slice])
-        return out
+        """Normalize features."""
+        return self.stats.normalize(features)
 
     def unnormalize(self, features):
-        """Undo feature normalization using per-part stats."""
-        gr = slice(0, self.global_root_dim)
-        lr = slice(self.global_root_dim, self.global_root_dim + self.local_root_dim)
-        out = torch.empty_like(features, device=features.device, dtype=features.dtype)
-        out[..., gr] = self.global_root_stats.unnormalize(features[..., gr])
-        out[..., lr] = self.local_root_stats.unnormalize(features[..., lr])
-        out[..., self.body_slice] = self.body_stats.unnormalize(features[..., self.body_slice])
-        return out
+        """Undo feature normalization."""
+        return self.stats.unnormalize(features)
 
     def create_conditions_from_constraints(
         self,

--- a/kimodo/motion_rep/reps/kimodo_motionrep.py
+++ b/kimodo/motion_rep/reps/kimodo_motionrep.py
@@ -53,6 +53,7 @@ class KimodoMotionRep(MotionRepBase):
         local_joint_rots: torch.Tensor,
         root_positions: torch.Tensor,
         to_normalize: bool,
+        to_canonicalize: bool = False,
         lengths: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Convert local rotations and root trajectory into smooth-root features.
@@ -61,6 +62,7 @@ class KimodoMotionRep(MotionRepBase):
             local_joint_rots: Local joint rotation matrices ``[B, T, J, 3, 3]``.
             root_positions: Root positions ``[B, T, 3]``.
             to_normalize: Whether to normalize output features.
+            to_canonicalize: Whether to canonicalize output features (False by default).
             lengths: Optional valid lengths for variable-length batches.
 
         Returns:
@@ -100,6 +102,9 @@ class KimodoMotionRep(MotionRepBase):
             ],
             "batch time *",
         )
+
+        if to_canonicalize:
+            features = self.canonicalize(features, normalized=False)
 
         if to_normalize:
             features = self.normalize(features)

--- a/kimodo/motion_rep/reps/tmr_motionrep.py
+++ b/kimodo/motion_rep/reps/tmr_motionrep.py
@@ -15,13 +15,14 @@ from .base import MotionRepBase
 
 
 class TMRMotionRep(MotionRepBase):
-    """Motion representation with global root and global joint positions.
+    """Motion representation with global root and local joint positions.
+    The local joint positions are rotation invariant (they all face z+)
 
     Feature layout:
     - root position ``(x, y, z)``
     - root heading as ``(cos(theta), sin(theta))``
-    - local joint positions (root removed, ground-referenced)
-    - global joint velocities
+    - local joint positions (root and rotation removed)
+    - local joint velocities (rotation removed)
     - binary foot contacts
     """
 
@@ -56,6 +57,7 @@ class TMRMotionRep(MotionRepBase):
         posed_joints: Optional[torch.Tensor] = None,
         *,
         to_normalize: bool,
+        to_canonicalize: bool = False,
         lengths: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Convert motion inputs to this feature representation.
@@ -68,6 +70,7 @@ class TMRMotionRep(MotionRepBase):
             posed_joints: Optional precomputed global joint positions
                 ``[B, T, J, 3]``. If passed, FK is skipped.
             to_normalize: Whether to normalize output features.
+            to_canonicalize: Whether to canonicalize output features (False by default).
             lengths: Optional valid lengths for variable-length batches.
 
         Returns:
@@ -98,10 +101,16 @@ class TMRMotionRep(MotionRepBase):
 
         ground_offset = 0 * root_positions
         ground_offset[..., 1] = root_positions[..., 1]
+
         local_joints_positions = local_joints_positions_origin_is_pelvis[:, :, 1:] + ground_offset[:, :, None]
         velocities = compute_vel_xyz(global_positions, self.fps, lengths=lengths)
-        foot_contacts = foot_detect_from_pos_and_vel(global_positions, velocities, self.skeleton, 0.15, 0.10)
 
+        # Remove the heading angle for each frame
+        RF = RotateFeatures(-root_heading_angle)
+        local_joints_positions = RF.rotate_positions(local_joints_positions)
+        velocities = RF.rotate_positions(velocities)
+
+        foot_contacts = foot_detect_from_pos_and_vel(global_positions, velocities, self.skeleton, 0.15, 0.10)
         features, _ = einops.pack(
             [
                 root_positions,
@@ -112,6 +121,9 @@ class TMRMotionRep(MotionRepBase):
             ],
             "batch time *",
         )
+
+        if to_canonicalize:
+            features = self.canonicalize(features, normalized=False)
 
         if to_normalize:
             features = self.normalize(features)
@@ -143,8 +155,8 @@ class TMRMotionRep(MotionRepBase):
             [
                 RF.rotate_positions(root_pos),
                 RF.rotate_2d_positions(global_root_heading),
-                RF.rotate_positions(local_joints_positions),
-                RF.rotate_positions(velocities),
+                local_joints_positions,  # already rotation invariant
+                velocities,  # already rotation invariant
                 foot_contacts,
             ],
             "batch time *",

--- a/kimodo/scripts/run_text_encoder_server.py
+++ b/kimodo/scripts/run_text_encoder_server.py
@@ -25,6 +25,7 @@ TEXT_ENCODER_PRESETS = {
             "peft_model_name_or_path": "McGill-NLP/LLM2Vec-Meta-Llama-3-8B-Instruct-mntp-supervised",
             "dtype": "bfloat16",
             "llm_dim": 4096,
+            "device": "auto",
         },
         "display_name": "LLM2Vec",
     }
@@ -56,12 +57,14 @@ def _get_env(name: str, default):
     return os.getenv(name, default)
 
 
-def _build_text_encoder(name: str):
+def _build_text_encoder(name: str, fp32: bool = False):
     if name not in TEXT_ENCODER_PRESETS:
         available = ", ".join(sorted(TEXT_ENCODER_PRESETS))
         raise ValueError(f"Unknown TEXT_ENCODER='{name}'. Available: {available}")
     preset = TEXT_ENCODER_PRESETS[name]
     target_cls = resolve_target(preset["target"])
+    if fp32:
+        preset["kwargs"]["dtype"] = "float32"
     return target_cls(**preset["kwargs"])
 
 
@@ -77,6 +80,11 @@ def parse_args():
         "--tmp-folder",
         default=_get_env("TEXT_ENCODER_TMP_FOLDER", DEFAULT_TMP_FOLDER),
     )
+    parser.add_argument(
+        "--fp32",
+        action="store_true",
+        help="Uses fp32 for the text encoder rather than default bfloat16.",
+    )
     return parser.parse_args()
 
 
@@ -86,7 +94,7 @@ def main():
     server_port = int(_get_env("GRADIO_SERVER_PORT", DEFAULT_SERVER_PORT))
     theme, css = get_gradio_theme()
     os.makedirs(args.tmp_folder, exist_ok=True)
-    text_encoder = _build_text_encoder(args.text_encoder)
+    text_encoder = _build_text_encoder(args.text_encoder, args.fp32)
     display_name = TEXT_ENCODER_PRESETS[args.text_encoder]["display_name"]
     demo_wrapper_fn = DemoWrapper(text_encoder, args.tmp_folder)
 

--- a/kimodo/skeleton/definitions.py
+++ b/kimodo/skeleton/definitions.py
@@ -255,7 +255,7 @@ class SOMASkeleton30(SkeletonBase):
         local_joint_rots_mats[:, skel_slice] = local_joint_rots_subset
         return local_joint_rots_mats
 
-    @ensure_batched(local_joint_rots_full=4)
+    @ensure_batched(local_joint_rots_full=4) # [BT, J, 3, 3]
     def from_SOMASkeleton77(self, local_joint_rots_full: torch.Tensor) -> torch.Tensor:
         """Extract the 30-joint subset from 77-joint local rotation data."""
         skel_slice = self.get_skel_slice(self.somaskel77)


### PR DESCRIPTION
### Added
- [Kimodo-SOMA-RP-v1.1](https://huggingface.co/nvidia/Kimodo-SOMA-RP-v1.1) and [Kimodo-SOMA-SEED-v1.1](https://huggingface.co/nvidia/Kimodo-SOMA-SEED-v1.1) models and added support in the codebase. If not specified, the latest version of the models will be used automatically with the demo and CLI.
- [Kimodo Motion Generation Benchmark](https://huggingface.co/datasets/nvidia/Kimodo-Motion-Gen-Benchmark) for standardized evaluation of motion generation models training on the BONES-SEED dataset.
- Scripts to construct the full benchmark, generate motions for test cases, and compute evaluation metrics. 
- Documentation explaining the benchmark and how to use the evaluation pipeline.
- [TMR-SOMA-RP-v1](https://huggingface.co/nvidia/TMR-SOMA-RP-v1) motion-text embedding model to be used for evaluation metrics.
- Added option to load LLM2Vec text encoder in fp32 precision.

### Fixed
- Always use batch size 1 with LLM2Vec to avoid unexpected behavior of different embeddings based on batch size.
- Load LLM2Vec directly onto the GPU, if available.
- Updated documentation on constraints with more details.