### PR TITLE
Support standard T-pose as rest pose for BVH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2026-04-13]
+
+### Added
+- Option `--bvh_standard_tpose` to use standard T-pose for BVH file saved from `generate.py`
+- Option to use standard T-pose for BVH file saved or downloaded from demo
+- Option to input/output BVH files that use standard T-pose with `motion_convert.py`
+- Added BVH file containing the standard Kimodo T-pose to `kimodo/assets/skeletons/somaskel77/somaskel77_standard_tpose.bvh`
+- Updated documentation with these new options
+
 ## [2026-04-10]
 
 ### Added

--- a/docs/source/user_guide/cli.md
+++ b/docs/source/user_guide/cli.md
@@ -55,6 +55,12 @@ CLI generation uses a single **output stem** (`--output`) for all formats (NPZ, 
 
 Use the `--bvh` flag to also export BVH (SOMA only) to the same stem.
 
+### Output Rest Pose
+
+For SOMA-based Kimodo models, motions can be exported with respect to two different rest poses. The default rest pose, that is always used by the `NPZ` format, is a standard T-pose consistent with the canonical T-pose of the SOMA model. For `BVH` outputs, the default rest pose is a non-standard pose, but it is consistent with the BVH format of the [BONES-SEED dataset](https://huggingface.co/datasets/bones-studio/seed). To output a `BVH` file with the standard T-pose as the rest pose, you can use the `--bvh_standard_tpose` option.
+
+The standard T-pose used by Kimodo is available as a BVH file in the [repo assets](https://github.com/nv-tlabs/kimodo/tree/main/kimodo/assets/skeletons/somaskel77).
+
 ## Visualizing Generated Motions
 
 Motions generated with the CLI can be visualized in the demo UI. To do this, under "Load/Save" > "Motion", type in the path of the generated output npz file, then click "Load Motion" to load it into the viewer. If you used constraints when generating, those can also be loaded in in a similar way.
@@ -73,6 +79,7 @@ To see all available flags, run `kimodo_gen --help`. They are:
 - `--constraints`: Path to a JSON file containing constraints
 - `--output`: Output stem name (default: `output`). Used for all formats (NPZ, AMASS NPZ, CSV, BVH). With one sample, writes a single file per format (e.g. `test.npz`, `test.csv`). With multiple samples, creates a folder and writes `test_00.npz`, `test_01.npz`, … inside it. For SMPLX with one sample, AMASS is written to `stem_amass.npz` so it does not overwrite the main NPZ.
 - `--bvh`: Optional flag. When set, also export BVH (SOMA models only) using the same stem as `--output`.
+- `--bvh_standard_tpose`: If exporting BVH, export with the rest pose being the standard T-pose rather than the rest pose consistent with the BONES-SEED dataset.
 - `--seed`: Seed for reproducible results
 - `--no-postprocess`: Disable post-processing (includes foot skate cleanup and constraint optimization)
 - `--input_folder`: Folder containing meta.json and optional constraints.json. If set, generation settings are loaded from meta.json. These are found in demo example folders.

--- a/docs/source/user_guide/motion_convert.md
+++ b/docs/source/user_guide/motion_convert.md
@@ -34,8 +34,8 @@ Formats are inferred from file extensions and (for `.npz`) from file contents. Y
 |------|-----|--------|
 | AMASS `.npz` | Kimodo `.npz` | SMPL-X, 22 joints. Uses `--z-up` by default (same as Kimodo’s AMASS export). |
 | Kimodo `.npz` | AMASS `.npz` | Requires `local_rot_mats` with 22 joints (SMPL-X). |
-| SOMA `.bvh` | Kimodo `.npz` | Expects a **Kimodo-exported** SOMA BVH (same hierarchy as `save_motion_bvh`). |
-| Kimodo `.npz` | SOMA `.bvh` | Accepts 77 joints (SOMA full) or 30 joints (somaskel30, auto-expanded to 77 with relaxed-hand rest poses). |
+| SOMA `.bvh` | Kimodo `.npz` | Expects a **Kimodo-exported** SOMA BVH (same hierarchy as `save_motion_bvh`). If the BVH uses the standard T-pose as rest pose, pass in `--bvh_standard_tpose`. |
+| Kimodo `.npz` | SOMA `.bvh` | Accepts 77 joints (SOMA full) or 30 joints (somaskel30, auto-expanded to 77 with relaxed-hand rest poses). If you want the output BVH to use the standard T-pose as rest pose, pass in `--bvh_standard_tpose`. |
 | G1 `.csv` | Kimodo `.npz` | Rows of shape `(36,)` = root xyz + root quat + 29 joint angles (see [output_formats](output_formats.md#csv-format-for-kimodo-g1)). |
 | Kimodo `.npz` | G1 `.csv` | Requires 34 joints (G1). |
 
@@ -44,6 +44,7 @@ Formats are inferred from file extensions and (for `.npz`) from file contents. Y
 - **`--source-fps`**: Source motion frame rate in Hz (used before resampling to 30 Hz for Kimodo NPZ). If omitted, the tool auto-detects from `mocap_frame_rate` (AMASS), `Frame Time` (BVH), or defaults to **30** Hz. The legacy `--fps` alias is still accepted for backward compatibility.
 - **`--no-z-up`**: For AMASS, disable the Y-up ↔ Z-up transform (treat data as already in Kimodo Y-up, +Z forward).
 - **`--mujoco-rest-zero`**: For G1 CSV, match the `mujoco_rest_zero` flag used when the CSV was written (see `MujocoQposConverter.dict_to_qpos`).
+- **`--bvh_standard_tpose`**: If input or output is BVH: the BVH file uses the standard T-pose as its rest pose instead of the BONES-SEED rest pose.
 
 ### Examples
 

--- a/docs/source/user_guide/output_formats.md
+++ b/docs/source/user_guide/output_formats.md
@@ -16,14 +16,16 @@ Generated motions are stored as NPZ files (one file per sample, e.g. `motion_00.
 - `root_positions`: The (non-smoothed) trajectory of the actual root joint (e.g., pelvis) `[T, 3]`
 - `global_root_heading`: The heading direction output from the model `[T, 2]`
 
-For SOMA models, the exported NPZ uses the full **`somaskel77`** skeleton even though the model itself operates internally on the reduced **`somaskel30`** skeleton. This means the saved `posed_joints`, `global_rot_mats`, and `local_rot_mats` arrays are written in the 77-joint SOMA layout. Older 30-joint SOMA NPZ files may still exist and remain loadable for backward compatibility.
-
 Where:
 
 - `T`: number of frames
 - `J`: number of joints in the exported skeleton representation (`77` for SOMA NPZ exports, `34` for G1, `22` for SMPL-X)
 
 If multiple samples are generated, files are saved with suffixes like `_00`, `_01`, etc.
+
+For SOMA models, the exported NPZ uses the full **`somaskel77`** skeleton even though the model itself operates internally on the reduced **`somaskel30`** skeleton. This means the saved `posed_joints`, `global_rot_mats`, and `local_rot_mats` arrays are written in the 77-joint SOMA layout. Older 30-joint SOMA NPZ files may still exist and remain loadable for backward compatibility.
+
+Also for SOMA models, the output motion is saved such that the rest pose (i.e. zero pose) is the standard T-pose that Kimodo uses internally. This differs from the default behavior of BVH export (see below), which uses a rest pose consistent with the BONES-SEED dataset format. The standard T-pose as a BVH file is also available [in the assets of the repo](https://github.com/nv-tlabs/kimodo/tree/main/kimodo/assets/skeletons/somaskel77).
 
 ## BVH Format for Kimodo-SOMA
 
@@ -33,6 +35,7 @@ When using a SOMA model and passing the `--bvh` flag to CLI generation, Kimodo a
 - the exported hierarchy uses the full **`somaskel77`** skeleton
 - if the motion is still in internal `somaskel30` form, Kimodo converts it to `somaskel77` before writing the BVH
 - the file stores root translation plus per-joint local rotations for the clip at the generated frame rate
+- by default, the rest pose (i.e., zero pose) of the saved BVH file is consistent with the BONES-SEED dataset format. If you prefer a standard T-pose as the rest pose, pass in `--bvh_standard_tpose` when generating.
 
 The exporter writes a standard plain-text BVH file and scales joint offsets and root motion from meters to centimeters (same format as the SEED dataset release). If multiple samples are generated, files are saved with suffixes like `_00`, `_01`, etc.
 

--- a/kimodo/assets/skeletons/somaskel77/somaskel77_standard_tpose.bvh
+++ b/kimodo/assets/skeletons/somaskel77/somaskel77_standard_tpose.bvh
@@ -1,0 +1,395 @@
+HIERARCHY
+ROOT Root
+{
+  OFFSET 0.0 0.0 0.0
+  CHANNELS 6 Xposition Yposition Zposition Zrotation Yrotation Xrotation
+  JOINT Hips
+  {
+    OFFSET 0.0 100.0 0.0
+    CHANNELS 6 Xposition Yposition Zposition Zrotation Yrotation Xrotation
+    JOINT Spine1
+    {
+      OFFSET -0.013727 5.003763 -0.053727
+      CHANNELS 3 Zrotation Yrotation Xrotation
+      JOINT Spine2
+      {
+        OFFSET -0.0 7.125301 -0.029825
+        CHANNELS 3 Zrotation Yrotation Xrotation
+        JOINT Chest
+        {
+          OFFSET -1e-06 7.550063 -0.815971
+          CHANNELS 3 Zrotation Yrotation Xrotation
+          JOINT Neck1
+          {
+            OFFSET -0.181677 26.311295 -0.553348
+            CHANNELS 3 Zrotation Yrotation Xrotation
+            JOINT Neck2
+            {
+              OFFSET -3e-06 7.709397 2.302585
+              CHANNELS 3 Zrotation Yrotation Xrotation
+              JOINT Head
+              {
+                OFFSET -5e-06 6.128916 1.953709
+                CHANNELS 3 Zrotation Yrotation Xrotation
+                JOINT HeadEnd
+                {
+                  OFFSET 0.003598 16.065403 -1.835379
+                  CHANNELS 3 Zrotation Yrotation Xrotation
+                }
+                JOINT Jaw
+                {
+                  OFFSET 0.002637 0.475592 3.094941
+                  CHANNELS 3 Zrotation Yrotation Xrotation
+                }
+                JOINT LeftEye
+                {
+                  OFFSET 3.206381 5.380205 7.586883
+                  CHANNELS 3 Zrotation Yrotation Xrotation
+                }
+                JOINT RightEye
+                {
+                  OFFSET -3.22244 5.361869 7.558234
+                  CHANNELS 3 Zrotation Yrotation Xrotation
+                }
+              }
+            }
+          }
+          JOINT LeftShoulder
+          {
+            OFFSET 1.621652 23.237164 5.113413
+            CHANNELS 3 Zrotation Yrotation Xrotation
+            JOINT LeftArm
+            {
+              OFFSET 14.919846 2e-06 -5.502326
+              CHANNELS 3 Zrotation Yrotation Xrotation
+              JOINT LeftForeArm
+              {
+                OFFSET 28.739307 0.0 -0.002588
+                CHANNELS 3 Zrotation Yrotation Xrotation
+                JOINT LeftHand
+                {
+                  OFFSET 27.093981 -1e-06 0.002609
+                  CHANNELS 3 Zrotation Yrotation Xrotation
+                  JOINT LeftHandThumb1
+                  {
+                    OFFSET 2.276482 -1.392045 3.191413
+                    CHANNELS 3 Zrotation Yrotation Xrotation
+                    JOINT LeftHandThumb2
+                    {
+                      OFFSET 4.012836 -1.828127 1.641654
+                      CHANNELS 3 Zrotation Yrotation Xrotation
+                      JOINT LeftHandThumb3
+                      {
+                        OFFSET 2.798515 0.0 -3e-06
+                        CHANNELS 3 Zrotation Yrotation Xrotation
+                        JOINT LeftHandThumbEnd
+                        {
+                          OFFSET 3.180793 -4e-06 4e-06
+                          CHANNELS 3 Zrotation Yrotation Xrotation
+                        }
+                      }
+                    }
+                  }
+                  JOINT LeftHandIndex1
+                  {
+                    OFFSET 3.247555 -0.531998 2.296169
+                    CHANNELS 3 Zrotation Yrotation Xrotation
+                    JOINT LeftHandIndex2
+                    {
+                      OFFSET 6.364578 0.01206 0.1786
+                      CHANNELS 3 Zrotation Yrotation Xrotation
+                      JOINT LeftHandIndex3
+                      {
+                        OFFSET 3.662364 0.0 0.0
+                        CHANNELS 3 Zrotation Yrotation Xrotation
+                        JOINT LeftHandIndex4
+                        {
+                          OFFSET 2.329242 4e-06 4e-06
+                          CHANNELS 3 Zrotation Yrotation Xrotation
+                          JOINT LeftHandIndexEnd
+                          {
+                            OFFSET 2.759615 -0.180537 -0.113024
+                            CHANNELS 3 Zrotation Yrotation Xrotation
+                          }
+                        }
+                      }
+                    }
+                  }
+                  JOINT LeftHandMiddle1
+                  {
+                    OFFSET 3.163495 0.240981 1.000332
+                    CHANNELS 3 Zrotation Yrotation Xrotation
+                    JOINT LeftHandMiddle2
+                    {
+                      OFFSET 6.19078 -0.259278 -1.002548
+                      CHANNELS 3 Zrotation Yrotation Xrotation
+                      JOINT LeftHandMiddle3
+                      {
+                        OFFSET 4.35652 -4e-06 -1e-06
+                        CHANNELS 3 Zrotation Yrotation Xrotation
+                        JOINT LeftHandMiddle4
+                        {
+                          OFFSET 2.996877 -8e-06 0.0
+                          CHANNELS 3 Zrotation Yrotation Xrotation
+                          JOINT LeftHandMiddleEnd
+                          {
+                            OFFSET 2.304287 -0.294569 -0.031741
+                            CHANNELS 3 Zrotation Yrotation Xrotation
+                          }
+                        }
+                      }
+                    }
+                  }
+                  JOINT LeftHandRing1
+                  {
+                    OFFSET 2.882643 -0.053652 -0.322543
+                    CHANNELS 3 Zrotation Yrotation Xrotation
+                    JOINT LeftHandRing2
+                    {
+                      OFFSET 5.854541 -0.486202 -1.373841
+                      CHANNELS 3 Zrotation Yrotation Xrotation
+                      JOINT LeftHandRing3
+                      {
+                        OFFSET 4.350578 0.0 3e-06
+                        CHANNELS 3 Zrotation Yrotation Xrotation
+                        JOINT LeftHandRing4
+                        {
+                          OFFSET 2.651321 7e-06 2e-06
+                          CHANNELS 3 Zrotation Yrotation Xrotation
+                          JOINT LeftHandRingEnd
+                          {
+                            OFFSET 1.936105 0.077687 -7.1e-05
+                            CHANNELS 3 Zrotation Yrotation Xrotation
+                          }
+                        }
+                      }
+                    }
+                  }
+                  JOINT LeftHandPinky1
+                  {
+                    OFFSET 2.8655 -0.310005 -1.600378
+                    CHANNELS 3 Zrotation Yrotation Xrotation
+                    JOINT LeftHandPinky2
+                    {
+                      OFFSET 5.087849 -1.331141 -1.77123
+                      CHANNELS 3 Zrotation Yrotation Xrotation
+                      JOINT LeftHandPinky3
+                      {
+                        OFFSET 3.070974 4e-06 0.0
+                        CHANNELS 3 Zrotation Yrotation Xrotation
+                        JOINT LeftHandPinky4
+                        {
+                          OFFSET 1.549672 0.0 1e-06
+                          CHANNELS 3 Zrotation Yrotation Xrotation
+                          JOINT LeftHandPinkyEnd
+                          {
+                            OFFSET 1.944893 -0.157802 0.057219
+                            CHANNELS 3 Zrotation Yrotation Xrotation
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+          JOINT RightShoulder
+          {
+            OFFSET -1.380118 23.180309 5.214158
+            CHANNELS 3 Zrotation Yrotation Xrotation
+            JOINT RightArm
+            {
+              OFFSET -15.037196 1.2e-05 -5.545604
+              CHANNELS 3 Zrotation Yrotation Xrotation
+              JOINT RightForeArm
+              {
+                OFFSET -28.736639 2e-06 -0.002597
+                CHANNELS 3 Zrotation Yrotation Xrotation
+                JOINT RightHand
+                {
+                  OFFSET -27.133619 -0.0 0.002613
+                  CHANNELS 3 Zrotation Yrotation Xrotation
+                  JOINT RightHandThumb1
+                  {
+                    OFFSET -2.274032 -1.383988 3.163127
+                    CHANNELS 3 Zrotation Yrotation Xrotation
+                    JOINT RightHandThumb2
+                    {
+                      OFFSET -4.011429 -1.827466 1.640914
+                      CHANNELS 3 Zrotation Yrotation Xrotation
+                      JOINT RightHandThumb3
+                      {
+                        OFFSET -2.794935 -4e-06 -3e-06
+                        CHANNELS 3 Zrotation Yrotation Xrotation
+                        JOINT RightHandThumbEnd
+                        {
+                          OFFSET -3.183852 4e-06 1e-06
+                          CHANNELS 3 Zrotation Yrotation Xrotation
+                        }
+                      }
+                    }
+                  }
+                  JOINT RightHandIndex1
+                  {
+                    OFFSET -3.253266 -0.520057 2.282866
+                    CHANNELS 3 Zrotation Yrotation Xrotation
+                    JOINT RightHandIndex2
+                    {
+                      OFFSET -6.341917 0.012471 0.178266
+                      CHANNELS 3 Zrotation Yrotation Xrotation
+                      JOINT RightHandIndex3
+                      {
+                        OFFSET -3.654871 -8e-06 -0.0
+                        CHANNELS 3 Zrotation Yrotation Xrotation
+                        JOINT RightHandIndex4
+                        {
+                          OFFSET -2.327586 0.0 1e-06
+                          CHANNELS 3 Zrotation Yrotation Xrotation
+                          JOINT RightHandIndexEnd
+                          {
+                            OFFSET -2.76179 -0.180656 -0.113078
+                            CHANNELS 3 Zrotation Yrotation Xrotation
+                          }
+                        }
+                      }
+                    }
+                  }
+                  JOINT RightHandMiddle1
+                  {
+                    OFFSET -3.168106 0.246593 1.00103
+                    CHANNELS 3 Zrotation Yrotation Xrotation
+                    JOINT RightHandMiddle2
+                    {
+                      OFFSET -6.180828 -0.258836 -1.000895
+                      CHANNELS 3 Zrotation Yrotation Xrotation
+                      JOINT RightHandMiddle3
+                      {
+                        OFFSET -4.348901 0.0 -0.0
+                        CHANNELS 3 Zrotation Yrotation Xrotation
+                        JOINT RightHandMiddle4
+                        {
+                          OFFSET -3.00024 -4e-06 -2e-06
+                          CHANNELS 3 Zrotation Yrotation Xrotation
+                          JOINT RightHandMiddleEnd
+                          {
+                            OFFSET -2.30252 -0.29437 -0.031706
+                            CHANNELS 3 Zrotation Yrotation Xrotation
+                          }
+                        }
+                      }
+                    }
+                  }
+                  JOINT RightHandRing1
+                  {
+                    OFFSET -2.88569 -0.067952 -0.308858
+                    CHANNELS 3 Zrotation Yrotation Xrotation
+                    JOINT RightHandRing2
+                    {
+                      OFFSET -5.854198 -0.48613 -1.373731
+                      CHANNELS 3 Zrotation Yrotation Xrotation
+                      JOINT RightHandRing3
+                      {
+                        OFFSET -4.33881 -4e-06 -0.0
+                        CHANNELS 3 Zrotation Yrotation Xrotation
+                        JOINT RightHandRing4
+                        {
+                          OFFSET -2.654903 -4e-06 4e-06
+                          CHANNELS 3 Zrotation Yrotation Xrotation
+                          JOINT RightHandRingEnd
+                          {
+                            OFFSET -1.933568 0.077527 -5.2e-05
+                            CHANNELS 3 Zrotation Yrotation Xrotation
+                          }
+                        }
+                      }
+                    }
+                  }
+                  JOINT RightHandPinky1
+                  {
+                    OFFSET -2.866425 -0.342796 -1.584145
+                    CHANNELS 3 Zrotation Yrotation Xrotation
+                    JOINT RightHandPinky2
+                    {
+                      OFFSET -5.091371 -1.332055 -1.772385
+                      CHANNELS 3 Zrotation Yrotation Xrotation
+                      JOINT RightHandPinky3
+                      {
+                        OFFSET -3.062664 -4e-06 1e-06
+                        CHANNELS 3 Zrotation Yrotation Xrotation
+                        JOINT RightHandPinky4
+                        {
+                          OFFSET -1.546529 4e-06 -2e-06
+                          CHANNELS 3 Zrotation Yrotation Xrotation
+                          JOINT RightHandPinkyEnd
+                          {
+                            OFFSET -1.945119 -0.157718 0.057211
+                            CHANNELS 3 Zrotation Yrotation Xrotation
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    JOINT LeftLeg
+    {
+      OFFSET 10.043214 -8.434526 2.595655
+      CHANNELS 3 Zrotation Yrotation Xrotation
+      JOINT LeftShin
+      {
+        OFFSET -1e-06 -43.221752 -0.802913
+        CHANNELS 3 Zrotation Yrotation Xrotation
+        JOINT LeftFoot
+        {
+          OFFSET 1e-06 -42.155094 -3.481523
+          CHANNELS 3 Zrotation Yrotation Xrotation
+          JOINT LeftToeBase
+          {
+            OFFSET 0.0 -5.059472 13.231529
+            CHANNELS 3 Zrotation Yrotation Xrotation
+            JOINT LeftToeEnd
+            {
+              OFFSET -0.009607 -1.647619 6.513017
+              CHANNELS 3 Zrotation Yrotation Xrotation
+            }
+          }
+        }
+      }
+    }
+    JOINT RightLeg
+    {
+      OFFSET -10.047278 -8.29526 2.620317
+      CHANNELS 3 Zrotation Yrotation Xrotation
+      JOINT RightShin
+      {
+        OFFSET 1e-06 -43.362206 -0.805556
+        CHANNELS 3 Zrotation Yrotation Xrotation
+        JOINT RightFoot
+        {
+          OFFSET 2e-06 -42.117393 -3.478398
+          CHANNELS 3 Zrotation Yrotation Xrotation
+          JOINT RightToeBase
+          {
+            OFFSET -0.0 -5.079609 13.284196
+            CHANNELS 3 Zrotation Yrotation Xrotation
+            JOINT RightToeEnd
+            {
+              OFFSET 0.009532 -1.634378 6.460591
+              CHANNELS 3 Zrotation Yrotation Xrotation
+            }
+          }
+        }
+      }
+    }
+  }
+}
+MOTION
+Frames: 1
+Frame Time: 0.03333333333333333
+0.0 0.0 0.0 0.0 0.0 0.0 0.0 100.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0

--- a/kimodo/demo/ui.py
+++ b/kimodo/demo/ui.py
@@ -698,6 +698,12 @@ def create_gui(
                     ),
                     initial_value="NPZ",
                 )
+                gui_save_bvh_standard_tpose_checkbox = client.gui.add_checkbox(
+                    "Standard T-pose",
+                    initial_value=False,
+                    hint="For BVH export, use the standard T-pose rest skeleton.",
+                    visible=False,
+                )
                 gui_save_motion_button = client.gui.add_button(
                     "Save Motion",
                     hint="Save the current motion (format + path above)",
@@ -799,6 +805,7 @@ def create_gui(
                         motion.joints_pos[:, session.skeleton.root_idx, :],
                         skeleton=session.skeleton,
                         fps=float(session.model_fps),
+                        standard_tpose=bool(gui_save_bvh_standard_tpose_checkbox.value),
                     )
                 elif fmt == "CSV":
                     save_path = _coerce_save_path(save_path, ext=".csv")
@@ -1275,6 +1282,12 @@ def create_gui(
                     ),
                     initial_value="NPZ",
                 )
+                gui_download_bvh_standard_tpose_checkbox = client.gui.add_checkbox(
+                    "Standard T-pose",
+                    initial_value=False,
+                    hint="For BVH export, use the standard T-pose rest skeleton.",
+                    visible=False,
+                )
                 gui_download_button = client.gui.add_button(
                     "Download",
                     hint="Download the current motion (format + name above).",
@@ -1357,6 +1370,23 @@ def create_gui(
             def _update_motion_export_dropdown(loaded_model_name: str) -> None:
                 _update_format_dropdown(gui_download_format_dropdown, loaded_model_name)
                 _update_format_dropdown(gui_save_motion_format_dropdown, loaded_model_name)
+                _update_bvh_standard_tpose_visibility()
+
+            def _update_bvh_standard_tpose_visibility() -> None:
+                gui_save_bvh_standard_tpose_checkbox.visible = (
+                    str(gui_save_motion_format_dropdown.value).upper() == "BVH"
+                )
+                gui_download_bvh_standard_tpose_checkbox.visible = (
+                    str(gui_download_format_dropdown.value).upper() == "BVH"
+                )
+
+            @gui_save_motion_format_dropdown.on_update
+            def _(_event: viser.GuiEvent) -> None:
+                _update_bvh_standard_tpose_visibility()
+
+            @gui_download_format_dropdown.on_update
+            def _(_event: viser.GuiEvent) -> None:
+                _update_bvh_standard_tpose_visibility()
 
             def _coerce_download_filename(raw_name: str, *, ext: str) -> str:
                 """Coerce a user-entered filename to a safe basename with the desired extension.
@@ -1563,6 +1593,7 @@ def create_gui(
                             motion.joints_pos[:, session.skeleton.root_idx, :],  # root positions
                             skeleton=session.skeleton,
                             fps=float(session.model_fps),
+                            standard_tpose=bool(gui_download_bvh_standard_tpose_checkbox.value),
                         )
                         mime = "text/plain"
                     elif fmt == "CSV":

--- a/kimodo/exports/bvh.py
+++ b/kimodo/exports/bvh.py
@@ -65,6 +65,7 @@ def motion_to_bvh(
     *,
     skeleton,
     fps: float,
+    standard_tpose: bool = False,
 ) -> str:
     """Convert local rotations and root positions to BVH format; return UTF-8 string.
 
@@ -73,7 +74,7 @@ def motion_to_bvh(
         root_positions: (T, 3) or (1, T, 3) root joint positions (e.g. from posed joints).
         skeleton: Skeleton with bone_order_names, bvh_neutral_joints, etc.
         fps: Frames per second for the motion.
-
+        standard_tpose: If True, export with the rest pose being the standard T-pose rather than the rest pose consistent with the BONES-SEED dataset.
     Notes:
         BVH is plain-text. Root is named "Root" with ZYX rotation order; leaf joints
         have no End Site block.
@@ -95,9 +96,13 @@ def motion_to_bvh(
         local_rot_mats = skeleton.to_SOMASkeleton77(local_rot_mats)
         skeleton = skeleton.somaskel77
 
-    local_rot_mats, _ = skeleton.from_standard_tpose(local_rot_mats)
+    if standard_tpose:
+        neutral = skeleton.neutral_joints.detach().cpu().numpy()
+    else:
+        # transform local rots to the original rest pose consistent with the BONES-SEED dataset
+        local_rot_mats, _ = skeleton.from_standard_tpose(local_rot_mats)
+        neutral = skeleton.bvh_neutral_joints.detach().cpu().numpy()
 
-    neutral = skeleton.bvh_neutral_joints.detach().cpu().numpy()
     joint_names = list(skeleton.bone_order_names)
     parents = skeleton.joint_parents.detach().cpu().numpy().astype(int)
     root_idx = int(skeleton.root_idx)
@@ -126,7 +131,7 @@ def motion_to_bvh(
     ]
     _JOINT_CHANNELS = ["Zrotation", "Yrotation", "Xrotation"]
 
-    # Scale from meters to centimeters (match original BVH scale).
+    # Scale from meters to centimeters (match original SEED data BVH scale).
     neutral = neutral * 100
     root_xyz = root_xyz * 100
 
@@ -212,12 +217,19 @@ def motion_to_bvh_bytes(
     *,
     skeleton,
     fps: float,
+    standard_tpose: bool = False,
 ) -> bytes:
     """Convert local rotations and root positions to BVH bytes (UTF-8).
 
     Convenience wrapper around :func:`motion_to_bvh`.
     """
-    return motion_to_bvh(local_rot_mats, root_positions, skeleton=skeleton, fps=fps).encode("utf-8")
+    return motion_to_bvh(
+        local_rot_mats,
+        root_positions,
+        skeleton=skeleton,
+        fps=fps,
+        standard_tpose=standard_tpose,
+    ).encode("utf-8")
 
 
 def save_motion_bvh(
@@ -227,10 +239,11 @@ def save_motion_bvh(
     *,
     skeleton,
     fps: float,
+    standard_tpose: bool = False,
 ) -> None:
     """Write local rotations and root positions to a BVH file at the given path."""
     Path(path).write_text(
-        motion_to_bvh(local_rot_mats, root_positions, skeleton=skeleton, fps=fps),
+        motion_to_bvh(local_rot_mats, root_positions, skeleton=skeleton, fps=fps, standard_tpose=standard_tpose),
         encoding="utf-8",
     )
 
@@ -248,6 +261,8 @@ def read_bvh_frame_time_seconds(path: Union[str, Path]) -> float:
 def bvh_to_kimodo_motion(
     path: Union[str, Path],
     skeleton=None,
+    *,
+    standard_tpose: bool = False,
 ) -> Tuple:
     """Load a Kimodo-style SOMA BVH into a Kimodo motion dict.
 
@@ -277,6 +292,7 @@ def bvh_to_kimodo_motion(
             f"BVH has {local_rot_mats.shape[1]} joints but skeleton has {skeleton.nbjoints}; "
             "use a Kimodo-exported SOMA BVH or matching skeleton."
         )
-    local_rot_mats, _ = skeleton.to_standard_tpose(local_rot_mats)
+    if not standard_tpose:
+        local_rot_mats, _ = skeleton.to_standard_tpose(local_rot_mats)
 
     return complete_motion_dict(local_rot_mats, root_trans, skeleton, float(bvh_fps)), bvh_fps

--- a/kimodo/exports/motion_convert_lib.py
+++ b/kimodo/exports/motion_convert_lib.py
@@ -34,6 +34,7 @@ def convert_motion_files(
     source_fps: float | None = None,
     z_up: bool = True,
     mujoco_rest_zero: bool = False,
+    bvh_standard_tpose: bool = False,
 ) -> None:
     """Convert a motion file between Kimodo-supported formats.
 
@@ -53,6 +54,8 @@ def convert_motion_files(
             ``mocap_frame_rate``, or default 30.
         z_up: For AMASS conversions, apply the Z-up <-> Kimodo Y-up transform.
         mujoco_rest_zero: For G1 CSV, joint angles relative to MuJoCo rest pose.
+        bvh_standard_tpose: If input or output is BVH: the BVH file uses the standard T-pose 
+            as its rest pose instead of the BONES-SEED rest pose.
     """
     from_fmt = from_fmt or infer_source_format_from_path(input_path)
     to_fmt = to_fmt or infer_target_format_from_path(output_path, from_fmt)
@@ -83,7 +86,7 @@ def convert_motion_files(
 
     if pair == ("soma-bvh", "kimodo"):
         sk = build_skeleton(77)
-        motion, bvh_fps = bvh_to_kimodo_motion(input_path, skeleton=sk)
+        motion, bvh_fps = bvh_to_kimodo_motion(input_path, skeleton=sk, standard_tpose=bvh_standard_tpose)
         effective_source = source_fps if source_fps is not None else bvh_fps
         save_kimodo_npz_at_target_fps(motion, sk, effective_source, output_path)
         return
@@ -108,6 +111,7 @@ def convert_motion_files(
             data["root_positions"],
             skeleton=sk,
             fps=effective_source,
+            standard_tpose=bvh_standard_tpose,
         )
         return
 

--- a/kimodo/scripts/generate.py
+++ b/kimodo/scripts/generate.py
@@ -73,6 +73,11 @@ def parse_args():
         help="Also export BVH (SOMA models only); uses the same stem as --output.",
     )
     parser.add_argument(
+        "--bvh_standard_tpose",
+        action="store_true",
+        help="If exporting BVH, export with the rest pose being the standard T-pose rather than the rest pose consistent with the BONES-SEED dataset.",
+    )
+    parser.add_argument(
         "--no-postprocess",
         action="store_true",
         help="Don't apply motion post-processing to reduce foot skating (ignored for G1)",
@@ -391,7 +396,14 @@ def main():
                 joints_rot = torch.from_numpy(output["global_rot_mats"][0]).to(device)
                 local_rot_mats = global_rots_to_local_rots(joints_rot, skeleton)
                 root_positions = joints_pos[:, skeleton.root_idx, :]
-                save_motion_bvh(bvh_path, local_rot_mats, root_positions, skeleton=skeleton, fps=model.fps)
+                save_motion_bvh(
+                    bvh_path,
+                    local_rot_mats,
+                    root_positions,
+                    skeleton=skeleton,
+                    fps=model.fps,
+                    standard_tpose=args.bvh_standard_tpose,
+                )
             else:
                 out_dir, _, base_name = _output_dir_and_path(output_base, "motion", ".bvh")
                 print(f"Saving the BVH output to {out_dir}/ ({base_name}_00.bvh ...)")
@@ -406,6 +418,7 @@ def main():
                         root_positions,
                         skeleton=skeleton,
                         fps=model.fps,
+                        standard_tpose=args.bvh_standard_tpose,
                     )
 
 

--- a/kimodo/scripts/motion_convert.py
+++ b/kimodo/scripts/motion_convert.py
@@ -22,6 +22,7 @@ def run_convert(
     source_fps: float | None,
     z_up: bool,
     mujoco_rest_zero: bool,
+    bvh_standard_tpose: bool = False,
 ) -> None:
     """Thin wrapper kept for backward compatibility; delegates to :func:`convert_motion_files`."""
     convert_motion_files(
@@ -32,6 +33,7 @@ def run_convert(
         source_fps=source_fps,
         z_up=z_up,
         mujoco_rest_zero=mujoco_rest_zero,
+        bvh_standard_tpose=bvh_standard_tpose,
     )
 
 
@@ -78,6 +80,12 @@ def build_argparser() -> argparse.ArgumentParser:
         default=False,
         help="For G1 CSV: joint angles relative to MuJoCo rest (must match export).",
     )
+    p.add_argument(
+        "--bvh_standard_tpose",
+        action="store_true",
+        default=False,
+        help="If input or output is BVH: the BVH file uses the standard T-pose as its rest pose instead of the BONES-SEED rest pose.",
+    )
     return p
 
 
@@ -92,6 +100,7 @@ def main(argv: list[str] | None = None) -> int:
             source_fps=args.source_fps,
             z_up=not args.no_z_up,
             mujoco_rest_zero=args.mujoco_rest_zero,
+            bvh_standard_tpose=args.bvh_standard_tpose,
         )
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)


### PR DESCRIPTION
### Added
- Option `--bvh_standard_tpose` to use standard T-pose for BVH file saved from `generate.py`
- Option to use standard T-pose for BVH file saved or downloaded from demo
- Option to input/output BVH files that use standard T-pose with `motion_convert.py`
- Added BVH file containing the standard Kimodo T-pose to `kimodo/assets/skeletons/somaskel77/somaskel77_standard_tpose.bvh`
- Updated documentation with these new options