### PR TITLE
Fix bug in constraint metrics averaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2026-05-03]
+
+### Fixed
+- `benchmark/parse_folder.py` now averages each metric only over the testcases that actually report it. Previously, sparse constraint metrics (`constraint_root2d_acc`, `constraint_root2d_err`, `constraint_root2d_err_p95`, `constraint_fullbody_keyframe`, `constraint_end_effector`) were divided by the total motion count of the (split, category), including testcases of other constraint kinds that did not report the metric. This silently scaled values by `motions_with_metric / total_motions` (e.g. `constraint_root2d_acc` displayed as ~0.57 when the true value was ~0.93). Both the printed table and `summary_rows.json` are affected, including the combined constraints row that merges `constraints_withtext` and `constraints_notext`. Text-following metrics, foot-skate/contact metrics, and TMR metrics are unchanged.
+- Updated Kimodo benchmark results in the documentation with this fix applied.
+
 ## [2026-04-24]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Kimodo is a **ki**nematic **mo**tion **d**iffusi**o**n model trained on a large-
 This repository provides:
 - **Inference**: code and CLI to generate motions on both human and robot skeletons
 - **Interactive Demo**: easily author motions with a timeline interface of text prompts and kinematic controls
-- **Annotations**: [additional text descriptions](https://huggingface.co/datasets/nvidia/SEED-Timeline-Annotations) for the [BONES-SEED](https://huggingface.co/datasets/bones-studio/seed) dataset, including fine-grained temporal descriptions
 - **Benchmark**: [test cases](https://huggingface.co/datasets/nvidia/Kimodo-Motion-Gen-Benchmark) and evaluation code built on the [BONES-SEED](https://huggingface.co/datasets/bones-studio/seed) dataset to evaluate motion generation models based on text and constraint-following abilities
+- **Annotations**: fine-grained temporal text descriptions created for the Kimodo project are included in the [BONES-SEED](https://huggingface.co/datasets/bones-studio/seed) dataset. For more information on these labels, see our separate [Hugging Face repo](https://huggingface.co/datasets/nvidia/SEED-Timeline-Annotations).
 
 <div align="center">
   <img src="assets/teaser.gif" width="1280">
@@ -23,6 +23,7 @@ This repository provides:
 
 See the [full changelog](CHANGELOG.md) for a detailed list of all changes.
 
+- **[2026-05-03]** _FIX_: fixed a bug causing incorrect calculation of averaged metrics for constraint test cases in the benchmark
 - **[2026-04-24]** _NEW_: improved multi-prompt generation and better support for small VRAM GPUs via `TEXT_ENCODER_DEVICE=cpu` env var
 - **[2026-04-10]** Released the [Kimodo Motion Generation Benchmark](#kimodo-motion-generation-benchmark) alongside new v1.1 Kimodo-SOMA models
 - **[2026-03-19]** **Breaking:** Model inputs/outputs now use the SOMA 77-joint skeleton (`somaskel77`).

--- a/benchmark/parse_folder.py
+++ b/benchmark/parse_folder.py
@@ -74,16 +74,26 @@ def _parse_testcase_key(root: Path, testcase_dir: Path) -> tuple[str, str]:
     return split, category
 
 
-def _accumulate_weighted(acc: dict[str, float], metric_dict: dict[str, Any], weight: float) -> None:
+def _accumulate_weighted(
+    sum_acc: dict[str, float],
+    weight_acc: dict[str, float],
+    metric_dict: dict[str, Any],
+    weight: float,
+) -> None:
     for metric_name, value in metric_dict.items():
         if isinstance(value, (int, float)):
-            acc[metric_name] = acc.get(metric_name, 0.0) + float(value) * weight
+            sum_acc[metric_name] = sum_acc.get(metric_name, 0.0) + float(value) * weight
+            weight_acc[metric_name] = weight_acc.get(metric_name, 0.0) + weight
 
 
-def _to_averages(weighted_sum: dict[str, float], total_weight: float) -> dict[str, float]:
-    if total_weight <= 0:
-        return {}
-    return {k: v / total_weight for k, v in sorted(weighted_sum.items())}
+def _to_averages(
+    weighted_sum: dict[str, float], weight: dict[str, float]
+) -> dict[str, float]:
+    return {
+        k: v / weight[k]
+        for k, v in sorted(weighted_sum.items())
+        if weight.get(k, 0.0) > 0
+    }
 
 
 def _load_result_row(
@@ -138,9 +148,9 @@ def _build_tables(
         # Text-following table: Overview, Timeline single, Timeline multi.
         for category in TEXT_FOLLOWING_CATEGORIES:
             acc = row_acc[(split, category)]
-            per_motion_gen = _to_averages(acc["per_motion_mean_weighted_sum"], acc["num_motions"])
-            per_motion_gt = _to_averages(acc["per_motion_mean_gt_weighted_sum"], acc["num_motions"])
-            tmr_avg = _to_averages(acc["tmr_weighted_sum"], acc["tmr_weight"]) if acc["tmr_weight"] > 0 else {}
+            per_motion_gen = _to_averages(acc["per_motion_mean_weighted_sum"], acc["per_motion_mean_weight"])
+            per_motion_gt = _to_averages(acc["per_motion_mean_gt_weighted_sum"], acc["per_motion_mean_gt_weight"])
+            tmr_avg = _to_averages(acc["tmr_weighted_sum"], acc["tmr_weight"]) if acc["tmr_weight"] else {}
             r03_gen = tmr_avg.get("TMR/t2m_R/R03")
             r03_gt = tmr_avg.get("TMR/t2m_gt_R/R03")
             fid_gen_text = tmr_avg.get("TMR/FID/gen_text")
@@ -170,8 +180,8 @@ def _build_tables(
         # Constraints table: Constraints with text, Constraints without text.
         for category in CONSTRAINTS_CATEGORIES:
             acc = row_acc[(split, category)]
-            per_motion_gen = _to_averages(acc["per_motion_mean_weighted_sum"], acc["num_motions"])
-            per_motion_gt = _to_averages(acc["per_motion_mean_gt_weighted_sum"], acc["num_motions"])
+            per_motion_gen = _to_averages(acc["per_motion_mean_weighted_sum"], acc["per_motion_mean_weight"])
+            per_motion_gt = _to_averages(acc["per_motion_mean_gt_weighted_sum"], acc["per_motion_mean_gt_weight"])
             row_label = CONSTRAINTS_ROW_LABELS[category]
             row_dict: dict[str, Any] = {
                 "row": row_label,
@@ -556,9 +566,11 @@ def _build_summary(root: Path) -> dict[str, Any]:
                 "num_testcases": 0,
                 "num_motions": 0.0,
                 "per_motion_mean_weighted_sum": {},
+                "per_motion_mean_weight": {},
                 "per_motion_mean_gt_weighted_sum": {},
+                "per_motion_mean_gt_weight": {},
                 "tmr_weighted_sum": {},
-                "tmr_weight": 0.0,
+                "tmr_weight": {},
             }
 
     for testcase_dir in testcase_dirs:
@@ -569,25 +581,39 @@ def _build_summary(root: Path) -> dict[str, Any]:
         acc = row_acc[(split, category)]
         acc["num_testcases"] += 1
         acc["num_motions"] += num_motions
-        _accumulate_weighted(acc["per_motion_mean_weighted_sum"], per_motion_mean_gen, num_motions)
+        _accumulate_weighted(
+            acc["per_motion_mean_weighted_sum"],
+            acc["per_motion_mean_weight"],
+            per_motion_mean_gen,
+            num_motions,
+        )
         if per_motion_mean_gt:
-            _accumulate_weighted(acc["per_motion_mean_gt_weighted_sum"], per_motion_mean_gt, num_motions)
+            _accumulate_weighted(
+                acc["per_motion_mean_gt_weighted_sum"],
+                acc["per_motion_mean_gt_weight"],
+                per_motion_mean_gt,
+                num_motions,
+            )
         if tmr:
-            _accumulate_weighted(acc["tmr_weighted_sum"], tmr, num_motions)
-            acc["tmr_weight"] += num_motions
+            _accumulate_weighted(
+                acc["tmr_weighted_sum"],
+                acc["tmr_weight"],
+                tmr,
+                num_motions,
+            )
 
     rows: list[dict[str, Any]] = []
     for split in SPLITS:
         for category in ROW_CATEGORIES:
             acc = row_acc[(split, category)]
-            tmr_avg = _to_averages(acc["tmr_weighted_sum"], acc["tmr_weight"]) if acc["tmr_weight"] > 0 else {}
-            per_motion_gt_avg = _to_averages(acc["per_motion_mean_gt_weighted_sum"], acc["num_motions"])
+            tmr_avg = _to_averages(acc["tmr_weighted_sum"], acc["tmr_weight"]) if acc["tmr_weight"] else {}
+            per_motion_gt_avg = _to_averages(acc["per_motion_mean_gt_weighted_sum"], acc["per_motion_mean_gt_weight"])
             row_dict: dict[str, Any] = {
                 "split": split,
                 "category": category,
                 "num_testcases": acc["num_testcases"],
                 "num_motions": int(acc["num_motions"]),
-                "per_motion_mean": _to_averages(acc["per_motion_mean_weighted_sum"], acc["num_motions"]),
+                "per_motion_mean": _to_averages(acc["per_motion_mean_weighted_sum"], acc["per_motion_mean_weight"]),
                 "tmr": tmr_avg,
             }
             if per_motion_gt_avg:
@@ -597,36 +623,32 @@ def _build_summary(root: Path) -> dict[str, Any]:
         # Combined constraints row for this split.
         withtext = row_acc[(split, "constraints_withtext")]
         notext = row_acc[(split, "constraints_notext")]
-        combined_weight = withtext["num_motions"] + notext["num_motions"]
 
         combined_per_motion = defaultdict(float)
+        combined_per_motion_weight = defaultdict(float)
         combined_per_motion_gt = defaultdict(float)
+        combined_per_motion_gt_weight = defaultdict(float)
         combined_tmr = defaultdict(float)
-        combined_tmr_weight = withtext["tmr_weight"] + notext["tmr_weight"]
-        for source in (
-            withtext["per_motion_mean_weighted_sum"],
-            notext["per_motion_mean_weighted_sum"],
+        combined_tmr_weight = defaultdict(float)
+        for sum_key, weight_key, sum_acc, weight_acc in (
+            ("per_motion_mean_weighted_sum", "per_motion_mean_weight", combined_per_motion, combined_per_motion_weight),
+            ("per_motion_mean_gt_weighted_sum", "per_motion_mean_gt_weight", combined_per_motion_gt, combined_per_motion_gt_weight),
+            ("tmr_weighted_sum", "tmr_weight", combined_tmr, combined_tmr_weight),
         ):
-            for k, v in source.items():
-                combined_per_motion[k] += v
-        for source in (
-            withtext["per_motion_mean_gt_weighted_sum"],
-            notext["per_motion_mean_gt_weighted_sum"],
-        ):
-            for k, v in source.items():
-                combined_per_motion_gt[k] += v
-        for source in (withtext["tmr_weighted_sum"], notext["tmr_weighted_sum"]):
-            for k, v in source.items():
-                combined_tmr[k] += v
+            for src in (withtext, notext):
+                for k, v in src[sum_key].items():
+                    sum_acc[k] += v
+                for k, w in src[weight_key].items():
+                    weight_acc[k] += w
 
-        combined_tmr_avg = _to_averages(dict(combined_tmr), combined_tmr_weight) if combined_tmr_weight > 0 else {}
-        combined_gt_avg = _to_averages(dict(combined_per_motion_gt), combined_weight)
+        combined_tmr_avg = _to_averages(dict(combined_tmr), dict(combined_tmr_weight)) if combined_tmr_weight else {}
+        combined_gt_avg = _to_averages(dict(combined_per_motion_gt), dict(combined_per_motion_gt_weight))
         combined_row: dict[str, Any] = {
             "split": split,
             "category": "constraints",
             "num_testcases": withtext["num_testcases"] + notext["num_testcases"],
-            "num_motions": int(combined_weight),
-            "per_motion_mean": _to_averages(dict(combined_per_motion), combined_weight),
+            "num_motions": int(withtext["num_motions"] + notext["num_motions"]),
+            "per_motion_mean": _to_averages(dict(combined_per_motion), dict(combined_per_motion_weight)),
             "tmr": combined_tmr_avg,
         }
         if combined_gt_avg:

--- a/docs/source/benchmark/results.md
+++ b/docs/source/benchmark/results.md
@@ -36,10 +36,11 @@ These results are for the Kimodo model trained on the public [BONES-SEED](https:
 
 |  | With text FB Pos↓ | With text EE Pos↓ | With text EE Rot↓ | With text 2D Root↓ | With text Pelvis@95% | Without text FB Pos↓ | Without text EE Pos↓ | Without text EE Rot↓ | Without text 2D Root↓ | Without text Pelvis@95% |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| **Content** Ground Truth | 0.000 | 0.000 | - | 2.362 | 3.30 | 0.000 | 0.000 | - | 2.408 | 3.33 |
-| **Content** Kimodo | 1.316 | 1.762 | - | 3.064 | 5.62 | 1.277 | 1.691 | - | 2.952 | 5.56 |
-| **Repetition** Ground Truth | 0.000 | 0.000 | - | 2.220 | 3.35 | 0.000 | 0.000 | - | 2.195 | 3.34 |
-| **Repetition** Kimodo | 1.226 | 1.778 | - | 2.913 | 5.65 | 1.200 | 1.620 | - | 2.624 | 4.85 |
+| **Content** Ground Truth | 0.000 | 0.000 | - | 3.837 | 5.36 | 0.000 | 0.000 | - | 3.913 | 5.41 |
+| **Content** Kimodo | 3.421 | 3.817 | - | 4.979 | 9.14 | 3.320 | 3.664 | - | 4.797 | 9.03 |
+| **Repetition** Ground Truth | 0.000 | 0.000 | - | 3.607 | 5.44 | 0.000 | 0.000 | - | 3.567 | 5.42 |
+| **Repetition** Kimodo | 3.187 | 3.852 | - | 4.734 | 9.19 | 3.120 | 3.510 | - | 4.264 | 7.89 |
+
 
 
 ## Kimodo-SOMA-RP-v1.1
@@ -59,10 +60,10 @@ These results are for the Kimodo model trained on the full (proprietary) Bones R
 
 |  | With text FB Pos↓ | With text EE Pos↓ | With text EE Rot↓ | With text 2D Root↓ | With text Pelvis@95% | Without text FB Pos↓ | Without text EE Pos↓ | Without text EE Rot↓ | Without text 2D Root↓ | Without text Pelvis@95% |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| **Content** Ground Truth | 0.000 | 0.000 | - | 2.362 | 3.30 | 0.000 | 0.000 | - | 2.408 | 3.33 |
-| **Content** Kimodo | 1.126 | 1.398 | - | 2.819 | 4.78 | 1.129 | 1.382 | - | 2.714 | 4.54 |
-| **Repetition** Ground Truth | 0.000 | 0.000 | - | 2.220 | 3.35 | 0.000 | 0.000 | - | 2.195 | 3.34 |
-| **Repetition** Kimodo | 1.078 | 1.377 | - | 2.621 | 4.69 | 1.088 | 1.370 | - | 2.478 | 4.44 | 
+| **Content** Ground Truth | 0.000 | 0.000 | - | 3.837 | 5.36 | 0.000 | 0.000 | - | 3.913 | 5.41 |
+| **Content** Kimodo | 2.929 | 3.029 | - | 4.581 | 7.77 | 2.935 | 2.994 | - | 4.411 | 7.37 |
+| **Repetition** Ground Truth | 0.000 | 0.000 | - | 3.607 | 5.44 | 0.000 | 0.000 | - | 3.567 | 5.42 |
+| **Repetition** Kimodo | 2.804 | 2.983 | - | 4.260 | 7.63 | 2.829 | 2.969 | - | 4.027 | 7.21 |
 -->
 
 
@@ -88,9 +89,9 @@ Results are reported for two models:
 
 |  | With text FB Pos↓ | With text EE Pos↓ | With text EE Rot↓ | With text 2D Root↓ | With text Pelvis@95% | Without text FB Pos↓ | Without text EE Pos↓ | Without text EE Rot↓ | Without text 2D Root↓ | Without text Pelvis@95% |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| **Content** Ground Truth | 0.000 | 0.000 | - | 2.362 | 3.30 | 0.000 | 0.000 | - | 2.408 | 3.33 |
-| **Content** Kimodo-SOMA-SEED-v1.1 | 1.316 | 1.762 | - | 3.064 | 5.62 | 1.277 | 1.691 | - | 2.952 | 5.56 |
-| **Content** Kimodo-SOMA-RP-v1.1 | 1.126 | 1.398 | - | 2.819 | 4.78 | 1.129 | 1.382 | - | 2.714 | 4.54 |
-| **Repetition** Ground Truth | 0.000 | 0.000 | - | 2.220 | 3.35 | 0.000 | 0.000 | - | 2.195 | 3.34 |
-| **Repetition** Kimodo-SOMA-SEED-v1.1 | 1.226 | 1.778 | - | 2.913 | 5.65 | 1.200 | 1.620 | - | 2.624 | 4.85 |
-| **Repetition** Kimodo-SOMA-RP-v1.1 | 1.078 | 1.377 | - | 2.621 | 4.69 | 1.088 | 1.370 | - | 2.478 | 4.44 |
+| **Content** Ground Truth | 0.000 | 0.000 | - | 3.837 | 5.36 | 0.000 | 0.000 | - | 3.913 | 5.41 |
+| **Content** Kimodo-SOMA-SEED-v1.1 | 3.421 | 3.817 | - | 4.979 | 9.14 | 3.320 | 3.664 | - | 4.797 | 9.03 |
+| **Content** Kimodo-SOMA-RP-v1.1 | 2.929 | 3.029 | - | 4.581 | 7.77 | 2.935 | 2.994 | - | 4.411 | 7.37 |
+| **Repetition** Ground Truth | 0.000 | 0.000 | - | 3.607 | 5.44 | 0.000 | 0.000 | - | 3.567 | 5.42 |
+| **Repetition** Kimodo-SOMA-SEED-v1.1 | 3.187 | 3.852 | - | 4.734 | 9.19 | 3.120 | 3.510 | - | 4.264 | 7.89 |
+| **Repetition** Kimodo-SOMA-RP-v1.1 | 2.804 | 2.983 | - | 4.260 | 7.63 | 2.829 | 2.969 | - | 4.027 | 7.21 |


### PR DESCRIPTION
The previous aggregation divided each metric's weighted numerator by the
total motion count of the (split, category), which silently diluted any
metric not reported by every testcase. In particular, constraint_root2d_*
fired only on root2d/mixture testcases, constraint_fullbody_keyframe only
on fullbody/mixture, and constraint_end_effector only on end-effectors/
mixture. As a result, summary_rows.json values were scaled by
motions_with_metric / total_motions (e.g. constraint_root2d_acc reported
as ~0.57 when the true value was ~0.93).

Fix by tracking a per-metric weight dict alongside the weighted-sum dict
in _accumulate_weighted, and dividing per-metric in _to_averages.
The combined constraints row that merges withtext + notext now also
merges the per-metric weight dicts in parallel. TMR, foot-skate, and
foot-contact metrics are unchanged (they were already dense or used
their own scalar weight). Updates README.md, CHANGELOG.md, and the
benchmark results doc with the corrected numbers.