### PR TITLE
fix(demo): stabilize video export

### DIFF
--- a/kimodo/demo/ui.py
+++ b/kimodo/demo/ui.py
@@ -1486,6 +1486,7 @@ def create_gui(
                 if session is None:
                     return
                 recording_notification: viser.NotificationHandle | None = None
+                was_playing = session.playing
                 try:
                     recording_notification = event_client.add_notification(
                         title="Recording video...",
@@ -1501,6 +1502,7 @@ def create_gui(
                     width = _round_up_to_multiple(width, 16)
                     height = _round_up_to_multiple(height, 16)
                     original_frame = session.frame_idx
+                    session.playing = False
                     frames = []
                     for frame_idx in range(session.max_frame_idx + 1):
                         demo.set_frame(
@@ -1508,6 +1510,7 @@ def create_gui(
                             frame_idx,
                             update_timeline=True,
                         )
+                        event_client.flush()
                         frames.append(
                             event_client.get_render(
                                 height=height,
@@ -1518,6 +1521,7 @@ def create_gui(
 
                     # Restore the original frame (and timeline).
                     demo.set_frame(event_client.client_id, original_frame)
+                    event_client.flush()
 
                     import imageio.v3 as iio
 
@@ -1551,6 +1555,7 @@ def create_gui(
                         color="red",
                     )
                 finally:
+                    session.playing = was_playing
                     event_client.timeline.enable_constraints()
                     if recording_notification is not None:
                         recording_notification.remove()


### PR DESCRIPTION
• ## Summary
  - Stabilize video export from `Exports > Video > Download Video`.
  - Pause playback while recording export frames.
  - Flush each frame update before requesting the browser canvas render.
  - Restore the original frame and playback state after export finishes.

  ## Root Cause
  The video export path iterates over every frame, calls `demo.set_frame(...)`, and immediately requests a browser render with `event_client.get_render(...)`.

  That can race in two ways:
  - If playback is active, the background playback loop can advance `session.frame_idx` while export is also stepping frames.
  - Viser frame updates can remain in the websocket message buffer, so the render request may capture the previous or otherwise stale visual frame before the new frame is applied in the browser.

  As a result, exported videos could appear to have frames out of order or visually mixed.

  ## Fix
  During video export:
  - Save the current playback state.
  - Set `session.playing = False` to stop the background playback loop from changing frames.
  - Call `event_client.flush()` after each `demo.set_frame(...)` before `get_render(...)`.
  - Restore the original frame and flush it.
  - Restore the original playback state in `finally`.