### PR TITLE
Update Python requirement to >= 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "kimodo"
 version = "1.0.0"
 description = "Kimodo motion generation model"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = {text = "Apache-2.0"}
 dependencies = [
   "hydra-core>=1.3",


### PR DESCRIPTION
Due to py-soma-x, it needs >= 3.10 to resolve dependencies

```sh
  × No solution found when resolving dependencies:
  ╰─▶ Because the requested Python version (>=3.8) does not satisfy Python>=3.10 and py-soma-x==0.2.1 depends on
      Python>=3.10, we can conclude that py-soma-x==0.2.1 cannot be used.
      And because only py-soma-x==0.2.1 is available, we can conclude that all versions of py-soma-x cannot be used.
      And because kimodo[all] depends on py-soma-x and your project requires kimodo[all], we can conclude that your
      project's requirements are unsatisfiable.

      hint: The `requires-python` value (>=3.8) includes Python versions that are not supported by your dependencies (e.g.,
      py-soma-x==0.2.1 only supports >=3.10). Consider using a more restrictive `requires-python` value (like >=3.10).
```